### PR TITLE
Initialize project skeleton

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/tests'],
+  moduleNameMapper: {
+    '^@cypher-anywhere/core(.*)$': '<rootDir>/packages/core/src$1',
+    '^@cypher-anywhere/json-adapter(.*)$': '<rootDir>/packages/adapters/json-adapter/src$1'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "cypher-anywhere",
+  "private": true,
+  "workspaces": [
+    "packages/*",
+    "packages/adapters/*"
+  ],
+  "scripts": {
+    "build": "npm run build --workspaces",
+    "test": "npm run test --workspaces"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2",
+    "jest": "^29.6.1",
+    "ts-jest": "^29.1.1"
+  }
+}

--- a/packages/adapters/json-adapter/package.json
+++ b/packages/adapters/json-adapter/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@cypher-anywhere/json-adapter",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "dependencies": {
+    "@cypher-anywhere/core": "0.0.1"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "jest"
+  }
+}

--- a/packages/adapters/json-adapter/src/index.ts
+++ b/packages/adapters/json-adapter/src/index.ts
@@ -1,0 +1,51 @@
+import { StorageAdapter, NodeRecord, RelRecord, NodeScanSpec } from '@cypher-anywhere/core';
+import * as fs from 'fs';
+
+interface Dataset {
+  nodes: NodeRecord[];
+  relationships: RelRecord[];
+}
+
+export interface JsonAdapterOptions {
+  datasetPath?: string;
+  dataset?: Dataset;
+}
+
+export class JsonAdapter implements StorageAdapter {
+  private data: Dataset;
+
+  constructor(options: JsonAdapterOptions) {
+    if (options.dataset) {
+      this.data = options.dataset;
+    } else if (options.datasetPath) {
+      const text = fs.readFileSync(options.datasetPath, 'utf8');
+      this.data = JSON.parse(text);
+    } else {
+      throw new Error('dataset or datasetPath must be provided');
+    }
+  }
+
+  async getNodeById(id: number | string): Promise<NodeRecord | null> {
+    return this.data.nodes.find(n => n.id === id) || null;
+  }
+
+  async *scanNodes(spec: NodeScanSpec = {}): AsyncIterable<NodeRecord> {
+    const { label } = spec;
+    for (const node of this.data.nodes) {
+      if (!label || node.labels.includes(label)) {
+        yield node;
+      }
+    }
+  }
+
+  // Relationship APIs left unimplemented for this MVP
+  async getRelationshipById(id: number | string): Promise<RelRecord | null> {
+    return this.data.relationships.find(r => r.id === id) || null;
+  }
+
+  async *scanRelationships(): AsyncIterable<RelRecord> {
+    for (const rel of this.data.relationships) {
+      yield rel;
+    }
+  }
+}

--- a/packages/adapters/json-adapter/tsconfig.json
+++ b/packages/adapters/json-adapter/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../../core" }
+  ]
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@cypher-anywhere/core",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "jest"
+  }
+}

--- a/packages/core/src/CypherEngine.ts
+++ b/packages/core/src/CypherEngine.ts
@@ -1,0 +1,24 @@
+import { StorageAdapter, NodeRecord } from './storage/StorageAdapter';
+
+export interface CypherEngineOptions {
+  adapter: StorageAdapter;
+}
+
+export class CypherEngine {
+  private adapter: StorageAdapter;
+
+  constructor(options: CypherEngineOptions) {
+    this.adapter = options.adapter;
+  }
+
+  async *run(query: string): AsyncIterable<Record<string, unknown>> {
+    const trimmed = query.trim();
+    if (trimmed === 'MATCH (n) RETURN n') {
+      for await (const node of this.adapter.scanNodes()) {
+        yield { n: node };
+      }
+    } else {
+      throw new Error('Query not supported in this MVP');
+    }
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,2 @@
+export * from './CypherEngine';
+export * from './storage/StorageAdapter';

--- a/packages/core/src/storage/StorageAdapter.ts
+++ b/packages/core/src/storage/StorageAdapter.ts
@@ -1,0 +1,39 @@
+export interface NodeRecord {
+  id: number | string;
+  labels: string[];
+  properties: Record<string, unknown>;
+}
+
+export interface RelRecord {
+  id: number | string;
+  type: string;
+  startNode: number | string;
+  endNode: number | string;
+  properties: Record<string, unknown>;
+}
+
+export interface NodeScanSpec {
+  label?: string;
+}
+
+export interface StorageAdapter {
+  getNodeById(id: number | string): Promise<NodeRecord | null>;
+  scanNodes(spec?: NodeScanSpec): AsyncIterable<NodeRecord>;
+
+  getRelationshipById?(id: number | string): Promise<RelRecord | null>;
+  scanRelationships?(): AsyncIterable<RelRecord>;
+}
+
+export interface IndexMetadata {
+  label?: string;
+  type?: string;
+  properties: string[];
+  unique: boolean;
+  selectivity?: number;
+}
+
+export interface GraphStatistics {
+  nodeCount(label?: string): Promise<number>;
+  relCount(type?: string): Promise<number>;
+  distinctValues(label: string, property: string): Promise<number>;
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/tests/data/sample.json
+++ b/tests/data/sample.json
@@ -1,0 +1,9 @@
+{
+  "nodes": [
+    { "id": 1, "labels": ["Person"], "properties": { "name": "Keanu Reeves" } },
+    { "id": 2, "labels": ["Movie"], "properties": { "title": "The Matrix", "released": 1999 } }
+  ],
+  "relationships": [
+    { "id": 3, "type": "ACTED_IN", "startNode": 1, "endNode": 2, "properties": {} }
+  ]
+}

--- a/tests/json-adapter.test.ts
+++ b/tests/json-adapter.test.ts
@@ -1,0 +1,18 @@
+import { JsonAdapter } from '@cypher-anywhere/json-adapter';
+import { CypherEngine } from '@cypher-anywhere/core';
+import * as path from 'path';
+
+const datasetPath = path.join(__dirname, 'data', 'sample.json');
+
+describe('JsonAdapter + CypherEngine', () => {
+  it('returns all nodes for MATCH (n) RETURN n', async () => {
+    const adapter = new JsonAdapter({ datasetPath });
+    const engine = new CypherEngine({ adapter });
+    const results: any[] = [];
+    for await (const row of engine.run('MATCH (n) RETURN n')) {
+      results.push(row.n);
+    }
+    expect(results).toHaveLength(2);
+    expect(results[0].labels).toContain('Person');
+  });
+});

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "commonjs",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Summary
- lay out base TypeScript packages
- add simple in-memory JsonAdapter and CypherEngine
- provide basic dataset and example test
- document how to run the proof-of-concept

## Testing
- `npm test` *(fails: `jest` not found)*