### PR TITLE
Add label filtering support and tests

### DIFF
--- a/packages/core/src/CypherEngine.ts
+++ b/packages/core/src/CypherEngine.ts
@@ -13,12 +13,20 @@ export class CypherEngine {
 
   async *run(query: string): AsyncIterable<Record<string, unknown>> {
     const trimmed = query.trim();
-    if (trimmed === 'MATCH (n) RETURN n') {
-      for await (const node of this.adapter.scanNodes()) {
-        yield { n: node };
+
+    // Very small pattern matcher for either MATCH (n) RETURN n
+    // or MATCH (n:Label) RETURN n
+    const match = trimmed.match(/^MATCH\s+\((\w+)(?::(\w+))?\)\s+RETURN\s+\1$/);
+
+    if (match) {
+      const [, variable, label] = match;
+      const scanSpec = label ? { label } : undefined;
+      for await (const node of this.adapter.scanNodes(scanSpec)) {
+        yield { [variable]: node };
       }
-    } else {
-      throw new Error('Query not supported in this MVP');
+      return;
     }
+
+    throw new Error('Query not supported in this MVP');
   }
 }

--- a/tests/json-adapter.test.js
+++ b/tests/json-adapter.test.js
@@ -16,3 +16,22 @@ test('JsonAdapter + CypherEngine returns all nodes for MATCH (n) RETURN n', asyn
   assert.strictEqual(results.length, 2);
   assert.ok(results[0].labels.includes('Person'));
 });
+
+test('CypherEngine filters nodes by label', async (t) => {
+  const adapter = new JsonAdapter({ datasetPath });
+  const engine = new CypherEngine({ adapter });
+
+  const people = [];
+  for await (const row of engine.run('MATCH (p:Person) RETURN p')) {
+    people.push(row.p);
+  }
+  assert.strictEqual(people.length, 1);
+  assert.strictEqual(people[0].properties.name, 'Keanu Reeves');
+
+  const movies = [];
+  for await (const row of engine.run('MATCH (m:Movie) RETURN m')) {
+    movies.push(row.m);
+  }
+  assert.strictEqual(movies.length, 1);
+  assert.strictEqual(movies[0].properties.title, 'The Matrix');
+});


### PR DESCRIPTION
## Summary
- allow `CypherEngine` to parse `MATCH (n:Label) RETURN n`
- verify label-filtering behaviour in tests

## Testing
- `npm test`