### PR TITLE
Add basic typescript parser for write queries

### DIFF
--- a/packages/adapters/json-adapter/src/index.ts
+++ b/packages/adapters/json-adapter/src/index.ts
@@ -38,6 +38,31 @@ export class JsonAdapter implements StorageAdapter {
     }
   }
 
+  async createNode(labels: string[], properties: Record<string, unknown>): Promise<NodeRecord> {
+    const maxId = this.data.nodes.reduce((m, n) => Math.max(m, Number(n.id)), 0);
+    const id = maxId + 1;
+    const node: NodeRecord = { id, labels, properties };
+    this.data.nodes.push(node);
+    return node;
+  }
+
+  async findNode(labels: string[], properties: Record<string, unknown>): Promise<NodeRecord | null> {
+    for (const node of this.data.nodes) {
+      if (labels.length && !labels.every(l => node.labels.includes(l))) {
+        continue;
+      }
+      let ok = true;
+      for (const [k, v] of Object.entries(properties)) {
+        if (node.properties[k] !== v) {
+          ok = false;
+          break;
+        }
+      }
+      if (ok) return node;
+    }
+    return null;
+  }
+
   // Relationship APIs left unimplemented for this MVP
   async getRelationshipById(id: number | string): Promise<RelRecord | null> {
     return this.data.relationships.find(r => r.id === id) || null;

--- a/packages/core/src/CypherEngine.ts
+++ b/packages/core/src/CypherEngine.ts
@@ -1,4 +1,5 @@
 import { StorageAdapter, NodeRecord } from './storage/StorageAdapter';
+import { parse, MatchReturnQuery, CreateQuery, MergeQuery, CypherAST } from './parser/CypherParser';
 
 export interface CypherEngineOptions {
   adapter: StorageAdapter;
@@ -12,13 +13,51 @@ export class CypherEngine {
   }
 
   async *run(query: string): AsyncIterable<Record<string, unknown>> {
-    const trimmed = query.trim();
-    if (trimmed === 'MATCH (n) RETURN n') {
-      for await (const node of this.adapter.scanNodes()) {
-        yield { n: node };
+    const ast = parse(query) as CypherAST;
+    switch (ast.type) {
+      case 'MatchReturn': {
+        const scan = this.adapter.scanNodes(ast.label ? { label: ast.label } : {});
+        for await (const node of scan) {
+          // filter by properties if provided
+          if (ast.properties) {
+            let ok = true;
+            for (const [k, v] of Object.entries(ast.properties)) {
+              if (node.properties[k] !== v) {
+                ok = false;
+                break;
+              }
+            }
+            if (!ok) continue;
+          }
+          yield { [ast.variable]: node };
+        }
+        break;
       }
-    } else {
-      throw new Error('Query not supported in this MVP');
+      case 'Create': {
+        if (!this.adapter.createNode) {
+          throw new Error('Adapter does not support CREATE');
+        }
+        const node = await this.adapter.createNode(ast.label ? [ast.label] : [], ast.properties ?? {});
+        if (ast.returnVariable) {
+          yield { [ast.variable]: node };
+        }
+        break;
+      }
+      case 'Merge': {
+        if (!this.adapter.findNode || !this.adapter.createNode) {
+          throw new Error('Adapter does not support MERGE');
+        }
+        let node = await this.adapter.findNode(ast.label ? [ast.label] : [], ast.properties ?? {});
+        if (!node) {
+          node = await this.adapter.createNode(ast.label ? [ast.label] : [], ast.properties ?? {});
+        }
+        if (ast.returnVariable) {
+          yield { [ast.variable]: node };
+        }
+        break;
+      }
+      default:
+        throw new Error('Query not supported in this MVP');
     }
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,2 +1,3 @@
 export * from './CypherEngine';
 export * from './storage/StorageAdapter';
+export * from './parser/CypherParser';

--- a/packages/core/src/parser/CypherParser.ts
+++ b/packages/core/src/parser/CypherParser.ts
@@ -1,0 +1,216 @@
+export interface MatchReturnQuery {
+  type: 'MatchReturn';
+  variable: string;
+  label?: string;
+  properties?: Record<string, unknown>;
+}
+
+export interface CreateQuery {
+  type: 'Create';
+  variable: string;
+  label?: string;
+  properties?: Record<string, unknown>;
+  returnVariable?: string;
+}
+
+export interface MergeQuery {
+  type: 'Merge';
+  variable: string;
+  label?: string;
+  properties?: Record<string, unknown>;
+  returnVariable?: string;
+}
+
+export type CypherAST = MatchReturnQuery | CreateQuery | MergeQuery;
+
+interface Token {
+  type: 'keyword' | 'identifier' | 'number' | 'string' | 'punct';
+  value: string;
+}
+
+function tokenize(input: string): Token[] {
+  const tokens: Token[] = [];
+  let i = 0;
+  while (i < input.length) {
+    const rest = input.slice(i);
+    const ws = /^\s+/.exec(rest);
+    if (ws) {
+      i += ws[0].length;
+      continue;
+    }
+    const keyword = /^(MATCH|RETURN|CREATE|MERGE)\b/i.exec(rest);
+    if (keyword) {
+      tokens.push({ type: 'keyword', value: keyword[1].toUpperCase() });
+      i += keyword[0].length;
+      continue;
+    }
+    const ident = /^[_A-Za-z][_A-Za-z0-9]*/.exec(rest);
+    if (ident) {
+      tokens.push({ type: 'identifier', value: ident[0] });
+      i += ident[0].length;
+      continue;
+    }
+    const str = /^"([^"\\]|\\.)*"|^'([^'\\]|\\.)*'/.exec(rest);
+    if (str) {
+      tokens.push({ type: 'string', value: str[0] });
+      i += str[0].length;
+      continue;
+    }
+    const num = /^\d+(?:\.\d+)?/.exec(rest);
+    if (num) {
+      tokens.push({ type: 'number', value: num[0] });
+      i += num[0].length;
+      continue;
+    }
+    const punct = /^[(){}:,]/.exec(rest);
+    if (punct) {
+      tokens.push({ type: 'punct', value: punct[0] });
+      i += punct[0].length;
+      continue;
+    }
+    throw new Error(`Unexpected token near: ${rest}`);
+  }
+  return tokens;
+}
+
+class Parser {
+  private pos = 0;
+  constructor(private tokens: Token[]) {}
+
+  private current(): Token | undefined {
+    return this.tokens[this.pos];
+  }
+
+  private consume(type: Token['type'], value?: string): Token {
+    const token = this.current();
+    if (!token || token.type !== type || (value && token.value !== value)) {
+      throw new Error(`Expected ${value ?? type}`);
+    }
+    this.pos++;
+    return token;
+  }
+
+  private optional(type: Token['type'], value?: string): Token | null {
+    const token = this.current();
+    if (token && token.type === type && (!value || token.value === value)) {
+      this.pos++;
+      return token;
+    }
+    return null;
+  }
+
+  parse(): CypherAST {
+    const tok = this.current();
+    if (!tok || tok.type !== 'keyword') {
+      throw new Error('Expected query keyword');
+    }
+    if (tok.value === 'MATCH') return this.parseMatchReturn();
+    if (tok.value === 'CREATE') return this.parseCreate();
+    if (tok.value === 'MERGE') return this.parseMerge();
+    throw new Error('Parse error: unsupported query');
+  }
+
+  private parseIdentifier(): string {
+    return this.consume('identifier').value;
+  }
+
+  private parsePattern() {
+    this.consume('punct', '(');
+    const variable = this.parseIdentifier();
+    let label: string | undefined;
+    if (this.optional('punct', ':')) {
+      label = this.parseIdentifier();
+    }
+    let properties: Record<string, unknown> | undefined;
+    if (this.optional('punct', '{')) {
+      properties = this.parseProperties();
+      this.consume('punct', '}');
+    }
+    this.consume('punct', ')');
+    return { variable, label, properties };
+  }
+
+  private parseProperties(): Record<string, unknown> {
+    const props: Record<string, unknown> = {};
+    let first = true;
+    while (!this.optional('punct', '}')) {
+      if (!first) {
+        this.consume('punct', ',');
+      }
+      const key = this.parseIdentifier();
+      this.consume('punct', ':');
+      props[key] = this.parseValue();
+      first = false;
+      if (this.current()?.value === '}') {
+        break;
+      }
+    }
+    return props;
+  }
+
+  private parseValue(): unknown {
+    const tok = this.current();
+    if (!tok) throw new Error('Unexpected end of input');
+    if (tok.type === 'string') {
+      this.pos++;
+      return tok.value.slice(1, -1);
+    }
+    if (tok.type === 'number') {
+      this.pos++;
+      return Number(tok.value);
+    }
+    if (tok.type === 'identifier' && (tok.value === 'true' || tok.value === 'false')) {
+      this.pos++;
+      return tok.value === 'true';
+    }
+    throw new Error('Unexpected value');
+  }
+
+  private parseReturnVariable(): string | undefined {
+    if (this.optional('keyword', 'RETURN')) {
+      return this.parseIdentifier();
+    }
+    return undefined;
+  }
+
+  private parseMatchReturn(): MatchReturnQuery {
+    this.consume('keyword', 'MATCH');
+    const pattern = this.parsePattern();
+    this.consume('keyword', 'RETURN');
+    const ret = this.parseIdentifier();
+    if (ret !== pattern.variable) {
+      throw new Error('Parse error: return variable mismatch');
+    }
+    return { type: 'MatchReturn', variable: pattern.variable, label: pattern.label, properties: pattern.properties };
+  }
+
+  private parseCreate(): CreateQuery {
+    this.consume('keyword', 'CREATE');
+    const pattern = this.parsePattern();
+    const ret = this.parseReturnVariable();
+    if (ret && ret !== pattern.variable) {
+      throw new Error('Parse error: return variable mismatch');
+    }
+    return { type: 'Create', variable: pattern.variable, label: pattern.label, properties: pattern.properties, returnVariable: ret };
+  }
+
+  private parseMerge(): MergeQuery {
+    this.consume('keyword', 'MERGE');
+    const pattern = this.parsePattern();
+    const ret = this.parseReturnVariable();
+    if (ret && ret !== pattern.variable) {
+      throw new Error('Parse error: return variable mismatch');
+    }
+    return { type: 'Merge', variable: pattern.variable, label: pattern.label, properties: pattern.properties, returnVariable: ret };
+  }
+}
+
+export function parse(query: string): CypherAST {
+  const tokens = tokenize(query);
+  const parser = new Parser(tokens);
+  const ast = parser.parse();
+  if (parser['pos'] !== tokens.length) {
+    throw new Error('Unexpected tokens at end of query');
+  }
+  return ast;
+}

--- a/packages/core/src/storage/StorageAdapter.ts
+++ b/packages/core/src/storage/StorageAdapter.ts
@@ -20,6 +20,12 @@ export interface StorageAdapter {
   getNodeById(id: number | string): Promise<NodeRecord | null>;
   scanNodes(spec?: NodeScanSpec): AsyncIterable<NodeRecord>;
 
+  /** Optional: create a new node. Returns the created record. */
+  createNode?(labels: string[], properties: Record<string, unknown>): Promise<NodeRecord>;
+
+  /** Optional: find a node by labels and exact property match. */
+  findNode?(labels: string[], properties: Record<string, unknown>): Promise<NodeRecord | null>;
+
   getRelationshipById?(id: number | string): Promise<RelRecord | null>;
   scanRelationships?(): AsyncIterable<RelRecord>;
 }

--- a/tests/json-adapter.test.js
+++ b/tests/json-adapter.test.js
@@ -16,3 +16,40 @@ test('JsonAdapter + CypherEngine returns all nodes for MATCH (n) RETURN n', asyn
   assert.strictEqual(results.length, 2);
   assert.ok(results[0].labels.includes('Person'));
 });
+
+// Query with label filter
+test('CypherEngine supports MATCH (n:Person) RETURN n', async () => {
+  const adapter = new JsonAdapter({ datasetPath });
+  const engine = new CypherEngine({ adapter });
+  const results = [];
+  for await (const row of engine.run('MATCH (n:Person) RETURN n')) {
+    results.push(row.n);
+  }
+  assert.strictEqual(results.length, 1);
+  assert.deepStrictEqual(results[0].properties.name, 'Keanu Reeves');
+});
+
+// Create then match
+test('CypherEngine CREATE followed by MATCH finds new node', async () => {
+  const adapter = new JsonAdapter({ datasetPath });
+  const engine = new CypherEngine({ adapter });
+  for await (const _ of engine.run('CREATE (n:Person {name:"Alice"})')) {}
+  const results = [];
+  for await (const row of engine.run('MATCH (n:Person {name:"Alice"}) RETURN n')) {
+    results.push(row.n);
+  }
+  assert.strictEqual(results.length, 1);
+  assert.strictEqual(results[0].properties.name, 'Alice');
+});
+
+// Merge existing
+test('CypherEngine MERGE finds existing node', async () => {
+  const adapter = new JsonAdapter({ datasetPath });
+  const engine = new CypherEngine({ adapter });
+  const out = [];
+  for await (const row of engine.run('MERGE (n:Person {name:"Keanu Reeves"}) RETURN n')) {
+    out.push(row.n);
+  }
+  assert.strictEqual(out.length, 1);
+  assert.strictEqual(out[0].properties.name, 'Keanu Reeves');
+});

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -1,0 +1,37 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { parse } = require('../packages/core/dist/parser/CypherParser');
+
+// Simple match
+test('parse MATCH (n) RETURN n', () => {
+  const ast = parse('MATCH (n) RETURN n');
+  assert.strictEqual(ast.type, 'MatchReturn');
+  assert.strictEqual(ast.variable, 'n');
+  assert.strictEqual(ast.label, undefined);
+});
+
+// Match with label
+test('parse MATCH (n:Person) RETURN n', () => {
+  const ast = parse('MATCH (n:Person) RETURN n');
+  assert.strictEqual(ast.label, 'Person');
+});
+
+// Create node
+test('parse CREATE (n:Person {name:"Alice"}) RETURN n', () => {
+  const ast = parse('CREATE (n:Person {name:"Alice"}) RETURN n');
+  assert.strictEqual(ast.type, 'Create');
+  assert.strictEqual(ast.label, 'Person');
+  assert.strictEqual(ast.properties.name, 'Alice');
+});
+
+// Merge node without return
+test('parse MERGE (n {name:"Bob"})', () => {
+  const ast = parse('MERGE (n {name:"Bob"})');
+  assert.strictEqual(ast.type, 'Merge');
+  assert.strictEqual(ast.properties.name, 'Bob');
+});
+
+// Invalid query should throw
+test('parse unsupported query throws', () => {
+  assert.throws(() => parse('RETURN n'), /Parse error/);
+});


### PR DESCRIPTION
## Summary
- extend StorageAdapter with optional write helpers
- implement CREATE and MERGE handling in JsonAdapter
- overhaul CypherParser with token-based parser supporting MATCH, CREATE and MERGE
- update CypherEngine to execute CREATE and MERGE
- expand tests for parser and adapter/engine integration

## Testing
- `npm test`
