### PR TITLE
Add node and relationship lifecycle APIs

### DIFF
--- a/packages/core/src/CypherEngine.ts
+++ b/packages/core/src/CypherEngine.ts
@@ -1,5 +1,18 @@
-import { StorageAdapter, NodeRecord, TransactionCtx } from './storage/StorageAdapter';
-import { parse, MatchReturnQuery, CreateQuery, MergeQuery, CypherAST } from './parser/CypherParser';
+import {
+  StorageAdapter,
+  NodeRecord,
+  TransactionCtx,
+} from './storage/StorageAdapter';
+import {
+  parse,
+  MatchReturnQuery,
+  CreateQuery,
+  MergeQuery,
+  MatchDeleteQuery,
+  MatchSetQuery,
+  CreateRelQuery,
+  CypherAST,
+} from './parser/CypherParser';
 
 export interface CypherEngineOptions {
   adapter: StorageAdapter;
@@ -15,7 +28,12 @@ export class CypherEngine {
   async *run(query: string): AsyncIterable<Record<string, unknown>> {
     const ast = parse(query) as CypherAST;
     let tx: TransactionCtx | undefined;
-    const isWrite = ast.type === 'Create' || ast.type === 'Merge';
+    const isWrite =
+      ast.type === 'Create' ||
+      ast.type === 'Merge' ||
+      ast.type === 'MatchDelete' ||
+      ast.type === 'MatchSet' ||
+      ast.type === 'CreateRel';
     if (isWrite && this.adapter.beginTransaction) {
       tx = await this.adapter.beginTransaction();
     }
@@ -59,6 +77,108 @@ export class CypherEngine {
         }
         if (ast.returnVariable) {
           yield { [ast.variable]: node };
+        }
+        break;
+      }
+      case 'MatchDelete': {
+        if (ast.isRelationship) {
+          if (!this.adapter.scanRelationships || !this.adapter.deleteRelationship) {
+            throw new Error('Adapter does not support relationship delete');
+          }
+          for await (const rel of this.adapter.scanRelationships()) {
+            if (ast.label && rel.type !== ast.label) continue;
+            if (ast.properties) {
+              let ok = true;
+              for (const [k, v] of Object.entries(ast.properties)) {
+                if (rel.properties[k] !== v) {
+                  ok = false;
+                  break;
+                }
+              }
+              if (!ok) continue;
+            }
+            await this.adapter.deleteRelationship(rel.id);
+            break;
+          }
+        } else {
+          if (!this.adapter.scanNodes || !this.adapter.deleteNode) {
+            throw new Error('Adapter does not support node delete');
+          }
+          for await (const node of this.adapter.scanNodes(ast.label ? { label: ast.label } : {})) {
+            let ok = true;
+            if (ast.properties) {
+              for (const [k, v] of Object.entries(ast.properties)) {
+                if (node.properties[k] !== v) {
+                  ok = false;
+                  break;
+                }
+              }
+            }
+            if (!ok) continue;
+            await this.adapter.deleteNode(node.id);
+            break;
+          }
+        }
+        break;
+      }
+      case 'MatchSet': {
+        if (ast.isRelationship) {
+          if (!this.adapter.scanRelationships || !this.adapter.updateRelationshipProperties) {
+            throw new Error('Adapter does not support relationship update');
+          }
+          for await (const rel of this.adapter.scanRelationships()) {
+            if (ast.label && rel.type !== ast.label) continue;
+            if (ast.properties) {
+              let ok = true;
+              for (const [k, v] of Object.entries(ast.properties)) {
+                if (rel.properties[k] !== v) {
+                  ok = false;
+                  break;
+                }
+              }
+              if (!ok) continue;
+            }
+            await this.adapter.updateRelationshipProperties(rel.id, { [ast.property]: ast.value });
+            if (ast.returnVariable) {
+              rel.properties[ast.property] = ast.value;
+              yield { [ast.variable]: rel };
+            }
+            break;
+          }
+        } else {
+          if (!this.adapter.scanNodes || !this.adapter.updateNodeProperties) {
+            throw new Error('Adapter does not support node update');
+          }
+          for await (const node of this.adapter.scanNodes(ast.label ? { label: ast.label } : {})) {
+            let ok = true;
+            if (ast.properties) {
+              for (const [k, v] of Object.entries(ast.properties)) {
+                if (node.properties[k] !== v) {
+                  ok = false;
+                  break;
+                }
+              }
+            }
+            if (!ok) continue;
+            await this.adapter.updateNodeProperties(node.id, { [ast.property]: ast.value });
+            if (ast.returnVariable) {
+              node.properties[ast.property] = ast.value;
+              yield { [ast.variable]: node };
+            }
+            break;
+          }
+        }
+        break;
+      }
+      case 'CreateRel': {
+        if (!this.adapter.createNode || !this.adapter.createRelationship) {
+          throw new Error('Adapter does not support CREATE');
+        }
+        const start = await this.adapter.createNode(ast.start.label ? [ast.start.label] : [], ast.start.properties ?? {});
+        const end = await this.adapter.createNode(ast.end.label ? [ast.end.label] : [], ast.end.properties ?? {});
+        const rel = await this.adapter.createRelationship(ast.relType, start.id, end.id, ast.relProperties ?? {});
+        if (ast.returnVariable) {
+          yield { [ast.relVariable]: rel };
         }
         break;
       }

--- a/packages/core/src/storage/StorageAdapter.ts
+++ b/packages/core/src/storage/StorageAdapter.ts
@@ -27,11 +27,26 @@ export interface StorageAdapter {
   /** Optional: create a new node. Returns the created record. */
   createNode?(labels: string[], properties: Record<string, unknown>): Promise<NodeRecord>;
 
+  /** Optional: delete a node by id */
+  deleteNode?(id: number | string): Promise<void>;
+
+  /** Optional: update properties on an existing node */
+  updateNodeProperties?(id: number | string, properties: Record<string, unknown>): Promise<void>;
+
   /** Optional: find a node by labels and exact property match. */
   findNode?(labels: string[], properties: Record<string, unknown>): Promise<NodeRecord | null>;
 
   getRelationshipById?(id: number | string): Promise<RelRecord | null>;
   scanRelationships?(): AsyncIterable<RelRecord>;
+
+  /** Optional: create a new relationship */
+  createRelationship?(type: string, startNode: number | string, endNode: number | string, properties: Record<string, unknown>): Promise<RelRecord>;
+
+  /** Optional: delete a relationship by id */
+  deleteRelationship?(id: number | string): Promise<void>;
+
+  /** Optional: update properties on an existing relationship */
+  updateRelationshipProperties?(id: number | string, properties: Record<string, unknown>): Promise<void>;
 
   /** Optional transactional hooks */
   beginTransaction?(): Promise<TransactionCtx>;

--- a/tests/json-adapter.test.js
+++ b/tests/json-adapter.test.js
@@ -66,3 +66,54 @@ test('JsonAdapter transaction rollback discards changes', async () => {
   }
   assert.strictEqual(res.length, 0);
 });
+
+test('JsonAdapter node property updates and deletion', async () => {
+  const adapter = new JsonAdapter({ datasetPath });
+  const node = await adapter.createNode(['Test'], { x: 1 });
+  await adapter.updateNodeProperties(node.id, { x: 2 });
+  const fetched = await adapter.getNodeById(node.id);
+  assert.strictEqual(fetched.properties.x, 2);
+  await adapter.deleteNode(node.id);
+  const deleted = await adapter.getNodeById(node.id);
+  assert.strictEqual(deleted, null);
+});
+
+test('JsonAdapter relationship lifecycle', async () => {
+  const adapter = new JsonAdapter({ datasetPath });
+  const rel = await adapter.createRelationship('KNOWS', 1, 2, { since: 2020 });
+  await adapter.updateRelationshipProperties(rel.id, { since: 2021 });
+  const fetched = await adapter.getRelationshipById(rel.id);
+  assert.strictEqual(fetched.properties.since, 2021);
+  await adapter.deleteRelationship(rel.id);
+  const gone = await adapter.getRelationshipById(rel.id);
+  assert.strictEqual(gone, null);
+});
+
+test('CypherEngine node update and delete via SET and DELETE', async () => {
+  const adapter = new JsonAdapter({ datasetPath });
+  const engine = new CypherEngine({ adapter });
+  for await (const _ of engine.run('CREATE (n:Tmp {name:"T"})')) {}
+  for await (const row of engine.run('MATCH (n:Tmp {name:"T"}) SET n.age = 5 RETURN n')) {
+    assert.strictEqual(row.n.properties.age, 5);
+  }
+  for await (const _ of engine.run('MATCH (n:Tmp {name:"T"}) DELETE n')) {}
+  const remaining = [];
+  for await (const row of engine.run('MATCH (n:Tmp {name:"T"}) RETURN n')) { remaining.push(row); }
+  assert.strictEqual(remaining.length, 0);
+});
+
+test('CypherEngine relationship lifecycle via queries', async () => {
+  const adapter = new JsonAdapter({ datasetPath });
+  const engine = new CypherEngine({ adapter });
+  let rel;
+  for await (const row of engine.run('CREATE (a:A)-[r:REL {x:1}]->(b:B) RETURN r')) {
+    rel = row.r;
+  }
+  for await (const row of engine.run('MATCH ()-[r:REL {x:1}]->() SET r.x = 2 RETURN r')) {
+    assert.strictEqual(row.r.properties.x, 2);
+  }
+  for await (const _ of engine.run('MATCH ()-[r:REL {x:2}]->() DELETE r')) {}
+  const out = [];
+  for await (const row of engine.run('MATCH ()-[r:REL]->() RETURN r')) { out.push(row); }
+  assert.strictEqual(out.length, 0);
+});


### PR DESCRIPTION
## Summary
- extend `StorageAdapter` with node and relationship CRUD helpers
- implement the new helpers in `JsonAdapter`
- test node property updates, deletions and relationship lifecycle
- support SET/DELETE queries and relationship creation in parser/engine
- add e2e tests for new Cypher operations

## Testing
- `npm test`
