### PR TITLE
Add multi-statement runner and relationship MERGE

### DIFF
--- a/tests/json-adapter.test.js
+++ b/tests/json-adapter.test.js
@@ -117,3 +117,19 @@ test('CypherEngine relationship lifecycle via queries', async () => {
   for await (const row of engine.run('MATCH ()-[r:REL]->() RETURN r')) { out.push(row); }
   assert.strictEqual(out.length, 0);
 });
+
+test('CypherEngine multi-statement merge creates relationship between matches', async () => {
+  const adapter = new JsonAdapter({ datasetPath });
+  const engine = new CypherEngine({ adapter });
+  const script = `
+    MATCH (p:Person {name:"Keanu Reeves"}) RETURN p;
+    MATCH (m:Movie {title:"The Matrix"}) RETURN m;
+    MERGE (p)-[r:ACTED_IN]->(m) RETURN r
+  `;
+  const res = [];
+  for await (const row of engine.run(script)) {
+    if (row.r) res.push(row.r);
+  }
+  assert.strictEqual(res.length, 1);
+  assert.strictEqual(res[0].type, 'ACTED_IN');
+});

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -1,6 +1,6 @@
 const test = require('node:test');
 const assert = require('node:assert');
-const { parse } = require('../packages/core/dist/parser/CypherParser');
+const { parse, parseMany } = require('../packages/core/dist/parser/CypherParser');
 
 // Simple match
 test('parse MATCH (n) RETURN n', () => {
@@ -29,6 +29,20 @@ test('parse MERGE (n {name:"Bob"})', () => {
   const ast = parse('MERGE (n {name:"Bob"})');
   assert.strictEqual(ast.type, 'Merge');
   assert.strictEqual(ast.properties.name, 'Bob');
+});
+
+test('parse MERGE (a)-[r:REL]->(b) RETURN r', () => {
+  const ast = parse('MERGE (a)-[r:REL]->(b) RETURN r');
+  assert.strictEqual(ast.type, 'MergeRel');
+  assert.strictEqual(ast.relType, 'REL');
+  assert.strictEqual(ast.startVariable, 'a');
+  assert.strictEqual(ast.endVariable, 'b');
+});
+
+test('parseMany splits semicolon separated statements', () => {
+  const [q1, q2] = parseMany('CREATE (n) RETURN n; MATCH (n) RETURN n');
+  assert.strictEqual(q1.type, 'Create');
+  assert.strictEqual(q2.type, 'MatchReturn');
 });
 
 // Invalid query should throw


### PR DESCRIPTION
## Summary
- extend parser with `MergeRel` query and new `parseMany`
- support multiple statements and variable binding in `CypherEngine`
- implement MERGE for relationships between matched nodes
- test new parser features and end-to-end multi-statement script

## Testing
- `npm test`