### PR TITLE
Implement path-based FOREACH

### DIFF
--- a/packages/core/src/logical/LogicalPlan.ts
+++ b/packages/core/src/logical/LogicalPlan.ts
@@ -7,6 +7,7 @@ import {
   MatchSetQuery,
   CreateRelQuery,
   MergeRelQuery,
+  MatchPathQuery,
   ForeachQuery,
 } from '../parser/CypherParser';
 
@@ -20,6 +21,7 @@ export type LogicalPlan =
   | LogicalMatchSet
   | LogicalCreateRel
   | LogicalMergeRel
+  | LogicalMatchPath
   | LogicalForeach;
 
 export type LogicalMatchReturn = MatchReturnQuery;
@@ -29,6 +31,7 @@ export type LogicalMatchDelete = MatchDeleteQuery;
 export type LogicalMatchSet = MatchSetQuery;
 export type LogicalCreateRel = CreateRelQuery;
 export type LogicalMergeRel = MergeRelQuery;
+export type LogicalMatchPath = MatchPathQuery;
 export type LogicalForeach = ForeachQuery;
 
 export function astToLogical(ast: CypherAST): LogicalPlan {

--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -19,9 +19,45 @@ function evalExpr(expr: Expression, vars: Map<string, any>): any {
       return vars.get(expr.name);
     case 'Add':
       return String(evalExpr(expr.left, vars)) + String(evalExpr(expr.right, vars));
+    case 'Nodes':
+      return vars.get(expr.variable);
     default:
       throw new Error('Unknown expression');
   }
+}
+
+async function findPath(
+  adapter: StorageAdapter,
+  startId: number | string,
+  endId: number | string
+): Promise<NodeRecord[] | null> {
+  if (!adapter.scanRelationships || !adapter.getNodeById) {
+    throw new Error('Adapter does not support path finding');
+  }
+  const rels: RelRecord[] = [];
+  for await (const r of adapter.scanRelationships()) rels.push(r);
+  const queue: (Array<number | string>)[] = [[startId]];
+  const visited = new Set<number | string>([startId]);
+  while (queue.length > 0) {
+    const path = queue.shift()!;
+    const last = path[path.length - 1];
+    if (last === endId) {
+      const nodes: NodeRecord[] = [];
+      for (const id of path) {
+        const n = await adapter.getNodeById(id);
+        if (!n) return null;
+        nodes.push(n);
+      }
+      return nodes;
+    }
+    for (const rel of rels) {
+      if (rel.startNode === last && !visited.has(rel.endNode)) {
+        visited.add(rel.endNode);
+        queue.push([...path, rel.endNode]);
+      }
+    }
+  }
+  return null;
 }
 
 function evalWhere(where: WhereClause, vars: Map<string, any>): boolean {
@@ -188,24 +224,37 @@ export function logicalToPhysical(
         } else {
           if (!adapter.scanNodes || !adapter.updateNodeProperties)
             throw new Error('Adapter does not support node update');
-          for await (const node of adapter.scanNodes(plan.labels ? { labels: plan.labels } : {})) {
-            let ok = true;
-            if (plan.properties) {
-              for (const [k, v] of Object.entries(plan.properties)) {
-                if (node.properties[k] !== v) {
-                  ok = false;
-                  break;
-                }
+          const bound = vars.get(plan.variable) as NodeRecord | undefined;
+          if (bound && (!plan.labels || plan.labels.length === 0) && !plan.properties) {
+            const node = bound;
+            if (!plan.where || evalWhere(plan.where, vars)) {
+              const val = evalExpr(plan.value, vars);
+              await adapter.updateNodeProperties(node.id, { [plan.property]: val });
+              node.properties[plan.property] = val;
+              if (plan.returnVariable) {
+                yield { [plan.variable]: node };
               }
             }
-            if (!ok) continue;
-            vars.set(plan.variable, node);
-            if (plan.where && !evalWhere(plan.where, vars)) continue;
-            const val = evalExpr(plan.value, vars);
-            await adapter.updateNodeProperties(node.id, { [plan.property]: val });
-            node.properties[plan.property] = val;
-            if (plan.returnVariable) {
-              yield { [plan.variable]: node };
+          } else {
+            for await (const node of adapter.scanNodes(plan.labels ? { labels: plan.labels } : {})) {
+              let ok = true;
+              if (plan.properties) {
+                for (const [k, v] of Object.entries(plan.properties)) {
+                  if (node.properties[k] !== v) {
+                    ok = false;
+                    break;
+                  }
+                }
+              }
+              if (!ok) continue;
+              vars.set(plan.variable, node);
+              if (plan.where && !evalWhere(plan.where, vars)) continue;
+              const val = evalExpr(plan.value, vars);
+              await adapter.updateNodeProperties(node.id, { [plan.property]: val });
+              node.properties[plan.property] = val;
+              if (plan.returnVariable) {
+                yield { [plan.variable]: node };
+              }
             }
           }
         }
@@ -246,9 +295,59 @@ export function logicalToPhysical(
         }
         break;
       }
+      case 'MatchPath': {
+        if (!adapter.scanNodes)
+          throw new Error('Adapter does not support MATCH');
+        const starts: NodeRecord[] = [];
+        for await (const node of adapter.scanNodes(plan.start.labels ? { labels: plan.start.labels } : {})) {
+          let ok = true;
+          if (plan.start.properties) {
+            for (const [k, v] of Object.entries(plan.start.properties)) {
+              if (node.properties[k] !== v) {
+                ok = false;
+                break;
+              }
+            }
+          }
+          if (ok) starts.push(node);
+        }
+        const ends: NodeRecord[] = [];
+        for await (const node of adapter.scanNodes(plan.end.labels ? { labels: plan.end.labels } : {})) {
+          let ok = true;
+          if (plan.end.properties) {
+            for (const [k, v] of Object.entries(plan.end.properties)) {
+              if (node.properties[k] !== v) {
+                ok = false;
+                break;
+              }
+            }
+          }
+          if (ok) ends.push(node);
+        }
+        for (const s of starts) {
+          for (const e of ends) {
+            const path = await findPath(adapter, s.id, e.id);
+            if (path) {
+              vars.set(plan.pathVariable, path);
+              if (plan.returnVariable) {
+                yield { [plan.pathVariable]: path };
+              }
+              return;
+            }
+          }
+        }
+        break;
+      }
       case 'Foreach': {
         const innerPlan = logicalToPhysical(plan.statement, adapter);
-        for (const item of plan.list) {
+        let items: unknown[];
+        if (Array.isArray(plan.list)) {
+          items = plan.list;
+        } else {
+          const v = evalExpr(plan.list, vars);
+          items = Array.isArray(v) ? v : [];
+        }
+        for (const item of items) {
           vars.set(plan.variable, item);
           for await (const row of innerPlan(vars)) {
             yield row;

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -326,3 +326,13 @@ runOnAdapters('FOREACH variable drives SET', async engine => {
   for await (const row of engine.run(script)) if (row.c) last = row.c;
   assert.strictEqual(last.properties.num, 3);
 });
+
+runOnAdapters('FOREACH over path nodes sets property', async engine => {
+  const script =
+    'MATCH p=(a:Person {name:"Alice"})-[*]->(g:Genre {name:"Action"}); ' +
+    'FOREACH n IN nodes(p) MATCH (n) SET n.marked = true; ' +
+    'MATCH (n) WHERE n.marked = true RETURN n';
+  const out = [];
+  for await (const row of engine.run(script)) if (row.n) out.push(row.n);
+  assert.strictEqual(out.length, 3);
+});


### PR DESCRIPTION
## Summary
- extend parser to support `nodes(var)` expression and path matching
- allow FOREACH to iterate over expressions
- add physical plan execution for paths
- update MatchSet to update bound variables
- add e2e coverage for path-based FOREACH

## Testing
- `npm test`