### PR TITLE
Implement multi-hop match chains

### DIFF
--- a/packages/core/src/logical/LogicalPlan.ts
+++ b/packages/core/src/logical/LogicalPlan.ts
@@ -8,6 +8,7 @@ import {
   CreateRelQuery,
   MergeRelQuery,
   MatchPathQuery,
+  MatchChainQuery,
   ForeachQuery,
 } from '../parser/CypherParser';
 
@@ -22,6 +23,7 @@ export type LogicalPlan =
   | LogicalCreateRel
   | LogicalMergeRel
   | LogicalMatchPath
+  | LogicalMatchChain
   | LogicalForeach;
 
 export type LogicalMatchReturn = MatchReturnQuery;
@@ -32,6 +34,7 @@ export type LogicalMatchSet = MatchSetQuery;
 export type LogicalCreateRel = CreateRelQuery;
 export type LogicalMergeRel = MergeRelQuery;
 export type LogicalMatchPath = MatchPathQuery;
+export type LogicalMatchChain = MatchChainQuery;
 export type LogicalForeach = ForeachQuery;
 
 export function astToLogical(ast: CypherAST): LogicalPlan {


### PR DESCRIPTION
## Summary
- support `MatchChain` query type to parse multi-hop patterns
- implement execution logic for chain matching
- extend tokenizer for `<` and add chain parsing
- add comprehensive e2e tests for multi-hop match scenarios

## Testing
- `npm test`