### PR TITLE
Add GitHub pages demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,20 @@ for await (const row of engine.run('MATCH (n) RETURN n')) {
 }
 ```
 
+## GitHub Pages Demo
+
+A small demo is included under the `docs/` directory. After building the
+packages and the demo bundle you can open `docs/index.html` locally or via
+GitHub Pages to experiment with Cypher queries against an in-memory JSON
+graph.
+
+```bash
+npm run build
+npm run build:demo
+```
+
+The page shows the current graph data and lets you run queries that modify it.
+
 To run the example:
 
 ```bash

--- a/build-demo.js
+++ b/build-demo.js
@@ -1,0 +1,10 @@
+const esbuild = require('esbuild');
+
+esbuild.build({
+  entryPoints: ['demo/demo.ts'],
+  bundle: true,
+  outfile: 'docs/bundle.js',
+  format: 'esm',
+  sourcemap: true,
+  target: ['es2019']
+}).catch(() => process.exit(1));

--- a/demo/demo.ts
+++ b/demo/demo.ts
@@ -1,0 +1,38 @@
+import { CypherEngine } from '../packages/core/src/CypherEngine';
+import { JsonAdapter } from '../packages/adapters/json-adapter/src/index';
+
+const dataset = {
+  nodes: [
+    { id: 1, labels: ['Person'], properties: { name: 'Keanu Reeves' } },
+    { id: 2, labels: ['Movie'], properties: { title: 'The Matrix', released: 1999 } }
+  ],
+  relationships: [
+    { id: 3, type: 'ACTED_IN', startNode: 1, endNode: 2, properties: {} }
+  ]
+};
+
+const adapter = new JsonAdapter({ dataset });
+const engine = new CypherEngine({ adapter });
+
+function refreshGraph() {
+  const graphElem = document.getElementById('graph');
+  if (graphElem) graphElem.textContent = JSON.stringify(dataset, null, 2);
+}
+
+refreshGraph();
+
+const btn = document.getElementById('runBtn') as HTMLButtonElement;
+btn.addEventListener('click', async () => {
+  const query = (document.getElementById('query') as HTMLTextAreaElement).value;
+  const resultsElem = document.getElementById('results');
+  if (!resultsElem) return;
+  resultsElem.textContent = '';
+  try {
+    for await (const row of engine.run(query)) {
+      resultsElem.textContent += JSON.stringify(row, null, 2) + '\n';
+    }
+    refreshGraph();
+  } catch (err) {
+    resultsElem.textContent = 'Error: ' + (err as Error).message;
+  }
+});

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Cypher Anywhere Demo</title>
+  <style>
+    textarea { width: 100%; }
+    pre { background: #f0f0f0; padding: 1em; }
+  </style>
+</head>
+<body>
+  <h1>Cypher Anywhere Demo</h1>
+  <div>
+    <textarea id="query" rows="6" placeholder="Write Cypher query here"></textarea>
+    <br>
+    <button id="runBtn">Run Query</button>
+  </div>
+  <h2>Results</h2>
+  <pre id="results"></pre>
+  <h2>Graph Data</h2>
+  <pre id="graph"></pre>
+  <script type="module" src="bundle.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -8,11 +8,13 @@
   "scripts": {
     "build": "npm run build:packages",
     "build:packages": "tsc -b packages/core packages/adapters/json-adapter",
+    "build:demo": "node build-demo.js",
     "test": "npm run build && node --test tests/*.js"
   },
   "devDependencies": {
     "typescript": "^5.2.2",
     "jest": "^29.6.1",
-    "ts-jest": "^29.1.1"
+    "ts-jest": "^29.1.1",
+    "esbuild": "^0.20.0"
   }
 }


### PR DESCRIPTION
## Summary
- add a simple web demo using JsonAdapter and CypherEngine
- document demo usage in README
- add esbuild-based build script

## Testing
- `npm test`
- `npm run build`
