### PR TITLE
Fix demo deploy workflow cache

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -22,12 +22,12 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-          cache: 'npm'
       - run: npm install
       - run: npm run build
       - run: npm run build:demo
-      - uses: actions/upload-pages-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
+          name: github-pages
           path: docs
   deploy:
     needs: build
@@ -36,5 +36,9 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
       - id: deployment
         uses: actions/deploy-pages@v1
+        with:
+          artifact_name: github-pages


### PR DESCRIPTION
## Summary
- remove npm cache setting from deploy workflow to avoid missing lockfile error

## Testing
- `npm test`
