### PR TITLE
Fix demo deployment workflow

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -22,12 +22,12 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-          cache: 'npm'
       - run: npm install
       - run: npm run build
       - run: npm run build:demo
-      - uses: actions/upload-pages-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
+          name: github-pages
           path: docs
   deploy:
     needs: build
@@ -36,5 +36,9 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
       - id: deployment
         uses: actions/deploy-pages@v1
+        with:
+          artifact_name: github-pages

--- a/packages/adapters/json-adapter/src/index.ts
+++ b/packages/adapters/json-adapter/src/index.ts
@@ -6,7 +6,10 @@ import {
   TransactionCtx,
   IndexMetadata,
 } from '@cypher-anywhere/core';
-import * as fs from 'fs';
+// Use a dynamic require to avoid bundling the "fs" module in browser builds
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+declare const require: any;
+let fs: typeof import('fs') | undefined;
 
 interface Dataset {
   nodes: NodeRecord[];
@@ -29,7 +32,11 @@ export class JsonAdapter implements StorageAdapter {
     if (options.dataset) {
       this.data = options.dataset;
     } else if (options.datasetPath) {
-      const text = fs.readFileSync(options.datasetPath, 'utf8');
+      if (!fs) {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        fs = require('fs');
+      }
+      const text = fs!.readFileSync(options.datasetPath, 'utf8');
       this.data = JSON.parse(text);
     } else {
       throw new Error('dataset or datasetPath must be provided');


### PR DESCRIPTION
## Summary
- use dynamic `require` for the JsonAdapter so bundling the demo works in browsers
- remove npm cache from the demo workflow

## Testing
- `npm test`
