### PR TITLE
Fix demo build fs bundling

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -26,8 +26,9 @@ jobs:
       - run: npm install
       - run: npm run build
       - run: npm run build:demo
-      - uses: actions/upload-pages-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
+          name: github-pages
           path: docs
   deploy:
     needs: build
@@ -36,5 +37,9 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
       - id: deployment
         uses: actions/deploy-pages@v1
+        with:
+          artifact_name: github-pages

--- a/build-demo.js
+++ b/build-demo.js
@@ -6,5 +6,6 @@ esbuild.build({
   outfile: 'docs/bundle.js',
   format: 'esm',
   sourcemap: true,
-  target: ['es2019']
+  target: ['es2019'],
+  external: ['fs']
 }).catch(() => process.exit(1));

--- a/packages/adapters/json-adapter/src/index.ts
+++ b/packages/adapters/json-adapter/src/index.ts
@@ -6,7 +6,10 @@ import {
   TransactionCtx,
   IndexMetadata,
 } from '@cypher-anywhere/core';
-import * as fs from 'fs';
+import type * as fsType from 'fs';
+
+// Declare Node's require for TypeScript without pulling in Node types
+declare var require: (module: string) => unknown;
 
 interface Dataset {
   nodes: NodeRecord[];
@@ -29,6 +32,8 @@ export class JsonAdapter implements StorageAdapter {
     if (options.dataset) {
       this.data = options.dataset;
     } else if (options.datasetPath) {
+      // Lazy load to avoid bundling Node's fs in the browser build
+      const fs = require('fs') as typeof fsType;
       const text = fs.readFileSync(options.datasetPath, 'utf8');
       this.data = JSON.parse(text);
     } else {


### PR DESCRIPTION
## Summary
- exclude Node's `fs` module from esbuild demo bundle
- lazily require `fs` only when reading from a file so browser builds work

## Testing
- `npm test`
- `npm run build:demo` *(fails: Cannot find module 'esbuild')*