### PR TITLE
Support expression returns in queries

### DIFF
--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -387,3 +387,9 @@ runOnAdapters('multi-hop chain length 3', async engine => {
   assert.strictEqual(out.length, 1);
   assert.strictEqual(out[0].properties.name, 'Thriller');
 });
+
+runOnAdapters('return numeric addition expression', async engine => {
+  const out = [];
+  for await (const row of engine.run('MATCH (m:Movie) RETURN m.released+3')) out.push(row.value);
+  assert.deepStrictEqual(out.sort(), [2002, 2017]);
+});

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -8,12 +8,14 @@ test('parse MATCH (n) RETURN n', () => {
   assert.strictEqual(ast.type, 'MatchReturn');
   assert.strictEqual(ast.variable, 'n');
   assert.deepStrictEqual(ast.labels, []);
+  assert.deepStrictEqual(ast.returnExpression, { type: 'Variable', name: 'n' });
 });
 
 // Match with label
 test('parse MATCH (n:Person) RETURN n', () => {
   const ast = parse('MATCH (n:Person) RETURN n');
   assert.deepStrictEqual(ast.labels, ['Person']);
+  assert.deepStrictEqual(ast.returnExpression, { type: 'Variable', name: 'n' });
 });
 
 // Create node


### PR DESCRIPTION
## Summary
- extend `MatchReturn` AST nodes with a `returnExpression`
- parse `RETURN` clauses as expressions
- evaluate arithmetic addition numerically when operands are numbers
- output values when returning expressions
- test parser updates
- add e2e test for `MATCH (m:Movie) RETURN m.released+3`

## Testing
- `npm test`