### PR TITLE
Add ORDER BY, LIMIT, SKIP support

### DIFF
--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -439,3 +439,23 @@ runOnAdapters('UNWIND nodes from path', async engine => {
   for await (const row of engine.run(script)) if (row.n) out.push(row.n);
   assert.strictEqual(out.length, 3);
 });
+
+runOnAdapters('OPTIONAL MATCH missing returns zero rows', async engine => {
+  const out = [];
+  for await (const row of engine.run('OPTIONAL MATCH (n:Missing) RETURN n')) out.push(row.n);
+  assert.strictEqual(out.length, 0);
+});
+
+runOnAdapters('ORDER BY with SKIP and LIMIT', async engine => {
+  const q = 'MATCH (n:Person) RETURN n.name AS name ORDER BY n.name SKIP 1 LIMIT 1';
+  const out = [];
+  for await (const row of engine.run(q)) out.push(row.name);
+  assert.deepStrictEqual(out, ['Bob']);
+});
+
+runOnAdapters('RETURN multiple expressions with aliases', async engine => {
+  const q = 'MATCH (m:Movie) RETURN m.title AS title, m.released AS year ORDER BY year';
+  const out = [];
+  for await (const row of engine.run(q)) out.push(`${row.title}-${row.year}`);
+  assert.deepStrictEqual(out, ['The Matrix-1999', 'John Wick-2014']);
+});

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -8,14 +8,18 @@ test('parse MATCH (n) RETURN n', () => {
   assert.strictEqual(ast.type, 'MatchReturn');
   assert.strictEqual(ast.variable, 'n');
   assert.deepStrictEqual(ast.labels, []);
-  assert.deepStrictEqual(ast.returnExpression, { type: 'Variable', name: 'n' });
+  assert.deepStrictEqual(ast.returnItems, [
+    { expression: { type: 'Variable', name: 'n' }, alias: undefined }
+  ]);
 });
 
 // Match with label
 test('parse MATCH (n:Person) RETURN n', () => {
   const ast = parse('MATCH (n:Person) RETURN n');
   assert.deepStrictEqual(ast.labels, ['Person']);
-  assert.deepStrictEqual(ast.returnExpression, { type: 'Variable', name: 'n' });
+  assert.deepStrictEqual(ast.returnItems, [
+    { expression: { type: 'Variable', name: 'n' }, alias: undefined }
+  ]);
 });
 
 // Create node


### PR DESCRIPTION
## Summary
- support multiple RETURN expressions with ORDER BY, SKIP and LIMIT
- allow OPTIONAL MATCH keyword
- adjust physical plan for ordering and slicing
- add new e2e tests
- update parser tests for new AST shape

## Testing
- `npm test`