### PR TITLE
Add boolean logic support in WHERE

### DIFF
--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -76,17 +76,29 @@ function evalWhere(
   vars: Map<string, any>,
   params: Record<string, any>
 ): boolean {
-  const l = evalExpr(where.left, vars, params);
-  const r = evalExpr(where.right, vars, params);
-  switch (where.operator) {
-    case '=':
-      return l === r;
-    case '>':
-      return (l as any) > (r as any);
-    case '>=':
-      return (l as any) >= (r as any);
+  switch (where.type) {
+    case 'Condition': {
+      const l = evalExpr(where.left, vars, params);
+      const r = evalExpr(where.right, vars, params);
+      switch (where.operator) {
+        case '=':
+          return l === r;
+        case '>':
+          return (l as any) > (r as any);
+        case '>=':
+          return (l as any) >= (r as any);
+        default:
+          throw new Error('Unknown operator');
+      }
+    }
+    case 'And':
+      return evalWhere(where.left, vars, params) && evalWhere(where.right, vars, params);
+    case 'Or':
+      return evalWhere(where.left, vars, params) || evalWhere(where.right, vars, params);
+    case 'Not':
+      return !evalWhere(where.clause, vars, params);
     default:
-      throw new Error('Unknown operator');
+      throw new Error('Unknown where clause');
   }
 }
 

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -310,6 +310,24 @@ runOnAdapters('match relationship with WHERE', async engine => {
   assert.strictEqual(out[0].properties.flag, true);
 });
 
+runOnAdapters('match with WHERE using AND', async engine => {
+  const out = [];
+  for await (const row of engine.run('MATCH (n:Person) WHERE n.name = "Alice" AND n.name = "Bob" RETURN n')) out.push(row.n);
+  assert.strictEqual(out.length, 0);
+});
+
+runOnAdapters('match with WHERE using OR', async engine => {
+  const out = [];
+  for await (const row of engine.run('MATCH (n:Person) WHERE n.name = "Alice" OR n.name = "Bob" RETURN n')) out.push(row.n);
+  assert.strictEqual(out.length, 2);
+});
+
+runOnAdapters('match with WHERE using NOT', async engine => {
+  const out = [];
+  for await (const row of engine.run('MATCH (n:Person) WHERE NOT n.name = "Alice" RETURN n')) out.push(row.n);
+  assert.strictEqual(out.length, 2);
+});
+
 runOnAdapters('FOREACH create multiple nodes', async engine => {
   for await (const _ of engine.run('FOREACH x IN [1,2,3] CREATE (n:Batch)')) {}
   const out = [];


### PR DESCRIPTION
## Summary
- support AND/OR/NOT logic in WHERE clauses
- extend parser and physical plan to handle boolean expressions
- add e2e tests for boolean logic

## Testing
- `npm test`