### PR TITLE
Add relationship match support with e2e test

### DIFF
--- a/packages/core/src/parser/CypherParser.ts
+++ b/packages/core/src/parser/CypherParser.ts
@@ -8,6 +8,7 @@ export interface MatchReturnQuery {
   variable: string;
   labels?: string[];
   properties?: Record<string, unknown>;
+  isRelationship?: boolean;
   where?: WhereClause;
   returnItems: ReturnItem[];
   orderBy?: Expression;
@@ -709,6 +710,7 @@ class Parser {
         variable: pattern.variable,
         labels: pattern.labels,
         properties: pattern.properties,
+        isRelationship: pattern.isRel,
         where,
         returnItems: ret.items,
         orderBy: ret.orderBy,

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -310,6 +310,12 @@ runOnAdapters('match relationship with WHERE', async engine => {
   assert.strictEqual(out[0].properties.flag, true);
 });
 
+runOnAdapters('match all ACTED_IN relationships', async engine => {
+  const out = [];
+  for await (const row of engine.run('MATCH ()-[r:ACTED_IN]->() RETURN r')) out.push(row.r);
+  assert.strictEqual(out.length, 3);
+});
+
 runOnAdapters('match with WHERE using AND', async engine => {
   const out = [];
   for await (const row of engine.run('MATCH (n:Person) WHERE n.name = "Alice" AND n.name = "Bob" RETURN n')) out.push(row.n);


### PR DESCRIPTION
## Summary
- support returning relationships from MATCH
- update parser and physical plan for relationship matching
- cover new behaviour with e2e test

## Testing
- `npm test`