### PR TITLE
Add < and <= support in WHERE

### DIFF
--- a/packages/core/src/parser/CypherParser.ts
+++ b/packages/core/src/parser/CypherParser.ts
@@ -57,7 +57,12 @@ export type Expression =
   | { type: 'Avg'; expression: Expression };
 
 export type WhereClause =
-  | { type: 'Condition'; left: Expression; operator: '=' | '>' | '>='; right: Expression }
+  | {
+      type: 'Condition';
+      left: Expression;
+      operator: '=' | '>' | '>=' | '<' | '<=';
+      right: Expression;
+    }
   | { type: 'And'; left: WhereClause; right: WhereClause }
   | { type: 'Or'; left: WhereClause; right: WhereClause }
   | { type: 'Not'; clause: WhereClause };
@@ -535,9 +540,11 @@ class Parser {
       }
       const left = this.parseValue();
       const opTok = this.consume('punct');
-      let op: '=' | '>' | '>=' = opTok.value as any;
+      let op: '=' | '>' | '>=' | '<' | '<=' = opTok.value as any;
       if (opTok.value === '>' && this.optional('punct', '=')) {
         op = '>=';
+      } else if (opTok.value === '<' && this.optional('punct', '=')) {
+        op = '<=';
       }
       const right = this.parseValue();
       return { type: 'Condition', left, operator: op, right };

--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -87,6 +87,10 @@ function evalWhere(
           return (l as any) > (r as any);
         case '>=':
           return (l as any) >= (r as any);
+        case '<':
+          return (l as any) < (r as any);
+        case '<=':
+          return (l as any) <= (r as any);
         default:
           throw new Error('Unknown operator');
       }

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -303,6 +303,13 @@ runOnAdapters('match with WHERE inequality', async engine => {
   assert.strictEqual(out[0].properties.title, 'John Wick');
 });
 
+runOnAdapters('match with WHERE less than inequality', async engine => {
+  const out = [];
+  for await (const row of engine.run('MATCH (m:Movie) WHERE m.released < 2000 RETURN m')) out.push(row.m);
+  assert.strictEqual(out.length, 1);
+  assert.strictEqual(out[0].properties.title, 'The Matrix');
+});
+
 runOnAdapters('match relationship with WHERE', async engine => {
   const out = [];
   for await (const row of engine.run('MATCH ()-[r:ACTED_IN]->() WHERE r.role = "Neo" SET r.flag = true RETURN r')) out.push(row.r);


### PR DESCRIPTION
## Summary
- support `<` and `<=` operators in WHERE clause parsing and evaluation
- test WHERE less-than inequality via e2e test

## Testing
- `npm test`