### PR TITLE
Fix ORDER BY DESC and alias sorting

### DIFF
--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -209,10 +209,13 @@ export function logicalToPhysical(
           vars.set(plan.variable, rec);
           if (plan.where && !evalWhere(plan.where, vars, params)) return;
           const row: Record<string, unknown> = {};
+          const aliasVars = new Map(vars);
           plan.returnItems.forEach((item, idx) => {
-            row[aliasFor(item, idx)] = evalExpr(item.expression, vars, params);
+            const val = evalExpr(item.expression, vars, params);
+            row[aliasFor(item, idx)] = val;
+            if (item.alias) aliasVars.set(item.alias, val);
           });
-          const order = plan.orderBy ? evalExpr(plan.orderBy, vars, params) : undefined;
+          const order = plan.orderBy ? evalExpr(plan.orderBy, aliasVars, params) : undefined;
           rows.push({ row, order, record: rec });
         };
 
@@ -312,7 +315,8 @@ export function logicalToPhysical(
             if (a.order === b.order) return 0;
             if (a.order === undefined) return 1;
             if (b.order === undefined) return -1;
-            return a.order > b.order ? 1 : -1;
+            const cmp = a.order > b.order ? 1 : -1;
+            return plan.orderDirection === 'DESC' ? -cmp : cmp;
           });
         }
 
@@ -617,10 +621,13 @@ export function logicalToPhysical(
         ): Promise<void> => {
           if (hop >= plan.hops.length) {
             const row: Record<string, unknown> = {};
+            const aliasVars = new Map(varsLocal);
             plan.returnItems.forEach((item, idx) => {
-              row[aliasFor(item, idx)] = evalExpr(item.expression, varsLocal, params);
+              const val = evalExpr(item.expression, varsLocal, params);
+              row[aliasFor(item, idx)] = val;
+              if (item.alias) aliasVars.set(item.alias, val);
             });
-            const order = plan.orderBy ? evalExpr(plan.orderBy, varsLocal, params) : undefined;
+            const order = plan.orderBy ? evalExpr(plan.orderBy, aliasVars, params) : undefined;
             rows.push({ row, order });
             return;
           }
@@ -674,7 +681,8 @@ export function logicalToPhysical(
             if (a.order === b.order) return 0;
             if (a.order === undefined) return 1;
             if (b.order === undefined) return -1;
-            return a.order > b.order ? 1 : -1;
+            const cmp = a.order > b.order ? 1 : -1;
+            return plan.orderDirection === 'DESC' ? -cmp : cmp;
           });
         }
         const startIdx = plan.skip ?? 0;

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -477,6 +477,13 @@ runOnAdapters('ORDER BY with SKIP and LIMIT', async engine => {
   assert.deepStrictEqual(out, ['Bob']);
 });
 
+runOnAdapters('ORDER BY DESC', async engine => {
+  const q = 'MATCH (m:Movie) RETURN m.released AS year ORDER BY year DESC';
+  const out = [];
+  for await (const row of engine.run(q)) out.push(row.year);
+  assert.deepStrictEqual(out, [2014, 1999]);
+});
+
 runOnAdapters('RETURN multiple expressions with aliases', async engine => {
   const q = 'MATCH (m:Movie) RETURN m.title AS title, m.released AS year ORDER BY year';
   const out = [];


### PR DESCRIPTION
## Summary
- support `ORDER BY` with direction specifiers
- allow alias variables to be used in ORDER BY
- add regression test for ORDER BY DESC

## Testing
- `npm test`