### PR TITLE
Fix ORDER BY with aggregation

### DIFF
--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -310,11 +310,21 @@ export function logicalToPhysical(
               }
               group.row[aliasFor(item, idx)] = val;
             });
-            rows.push({ row: group.row, record: group.record });
+            let order: any;
+            if (plan.orderBy) {
+              const aliasVars = new Map(vars);
+              plan.returnItems.forEach((it, i) => {
+                const alias = aliasFor(it, i);
+                aliasVars.set(alias, group.row[alias]);
+                if (it.alias) aliasVars.set(it.alias, group.row[alias]);
+              });
+              order = evalExpr(plan.orderBy, aliasVars, params);
+            }
+            rows.push({ row: group.row, order, record: group.record });
           }
         }
 
-        if (plan.orderBy && !hasAgg) {
+        if (plan.orderBy) {
           rows.sort((a, b) => {
             if (a.order === b.order) return 0;
             if (a.order === undefined) return 1;

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -541,6 +541,15 @@ runOnAdapters('GROUP BY with COUNT', async engine => {
   assert.strictEqual(res[2014], 1);
 });
 
+runOnAdapters('ORDER BY after aggregation', async engine => {
+  for await (const _ of engine.run('CREATE (m:Movie {title:"Extra", released:2014})')) {}
+  const q =
+    'MATCH (m:Movie) RETURN m.released AS year, COUNT(m) AS cnt ORDER BY cnt DESC';
+  const out = [];
+  for await (const row of engine.run(q)) out.push(`${row.year}:${row.cnt}`);
+  assert.deepStrictEqual(out, ['2014:2', '1999:1']);
+});
+
 runOnAdapters('UNION combines results', async engine => {
   const q =
     'MATCH (p:Person {name:"Alice"}) RETURN p.name AS name ' +


### PR DESCRIPTION
## Summary
- add e2e coverage for ordering aggregated results
- fix ORDER BY handling when RETURN contains aggregation

## Testing
- `npm test`