### PR TITLE
Implement OPTIONAL MATCH handling

### DIFF
--- a/packages/core/src/parser/CypherParser.ts
+++ b/packages/core/src/parser/CypherParser.ts
@@ -9,6 +9,7 @@ export interface MatchReturnQuery {
   labels?: string[];
   properties?: Record<string, unknown>;
   isRelationship?: boolean;
+  optional?: boolean;
   where?: WhereClause;
   returnItems: ReturnItem[];
   orderBy?: Expression;
@@ -276,10 +277,10 @@ class Parser {
     if (!tok || tok.type !== 'keyword') {
       throw new Error('Expected query keyword');
     }
-    if (tok.value === 'MATCH') return this.parseMatch();
+    if (tok.value === 'MATCH') return this.parseMatch(false);
     if (tok.value === 'OPTIONAL') {
       this.consume('keyword', 'OPTIONAL');
-      return this.parseMatch();
+      return this.parseMatch(true);
     }
     if (tok.value === 'CREATE') return this.parseCreate();
     if (tok.value === 'MERGE') return this.parseMerge();
@@ -642,7 +643,7 @@ class Parser {
     };
   }
 
-  private parseMatch(): CypherAST {
+  private parseMatch(optional = false): CypherAST {
     this.consume('keyword', 'MATCH');
     if (
       this.current()?.type === 'identifier' &&
@@ -727,13 +728,14 @@ class Parser {
         labels: pattern.labels,
         properties: pattern.properties,
         isRelationship: pattern.isRel,
+        optional,
         where,
-      returnItems: ret.items,
-      orderBy: ret.orderBy,
-      orderDirection: ret.orderDirection,
-      skip: ret.skip,
-      limit: ret.limit,
-    };
+        returnItems: ret.items,
+        orderBy: ret.orderBy,
+        orderDirection: ret.orderDirection,
+        skip: ret.skip,
+        limit: ret.limit,
+      };
     }
     if (next.value === 'DELETE') {
       this.consume('keyword', 'DELETE');

--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -16,7 +16,7 @@ function evalExpr(
       return expr.value;
     case 'Property': {
       const rec = vars.get(expr.variable) as NodeRecord | RelRecord | undefined;
-      if (!rec) throw new Error(`Unbound variable ${expr.variable}`);
+      if (!rec) return undefined;
       return rec.properties[expr.property];
     }
     case 'Variable':
@@ -327,9 +327,19 @@ export function logicalToPhysical(
         const start = plan.skip ?? 0;
         let end = rows.length;
         if (plan.limit !== undefined) end = Math.min(end, start + plan.limit);
-        for (let i = start; i < end; i++) {
-          vars.set(plan.variable, rows[i].record as any);
-          yield rows[i].row;
+        if (rows.length === 0 && plan.optional) {
+          vars.delete(plan.variable);
+          const row: Record<string, unknown> = {};
+          plan.returnItems.forEach((item, idx) => {
+            const val = evalExpr(item.expression, vars, params);
+            row[aliasFor(item, idx)] = val;
+          });
+          yield row;
+        } else {
+          for (let i = start; i < end; i++) {
+            vars.set(plan.variable, rows[i].record as any);
+            yield rows[i].row;
+          }
         }
         break;
       }

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -471,10 +471,19 @@ runOnAdapters('UNWIND nodes from path', async engine => {
   assert.strictEqual(out.length, 3);
 });
 
-runOnAdapters('OPTIONAL MATCH missing returns zero rows', async engine => {
+runOnAdapters('OPTIONAL MATCH missing returns null row', async engine => {
   const out = [];
   for await (const row of engine.run('OPTIONAL MATCH (n:Missing) RETURN n')) out.push(row.n);
-  assert.strictEqual(out.length, 0);
+  assert.strictEqual(out.length, 1);
+  assert.strictEqual(out[0], undefined);
+});
+
+runOnAdapters('OPTIONAL MATCH existing node returns it', async engine => {
+  const out = [];
+  const q = 'OPTIONAL MATCH (n:Person {name:"Alice"}) RETURN n';
+  for await (const row of engine.run(q)) out.push(row.n);
+  assert.strictEqual(out.length, 1);
+  assert.strictEqual(out[0].properties.name, 'Alice');
 });
 
 runOnAdapters('ORDER BY with SKIP and LIMIT', async engine => {


### PR DESCRIPTION
## Summary
- add `optional` flag to `MatchReturnQuery`
- parse `OPTIONAL MATCH` and mark queries accordingly
- gracefully handle unbound properties
- yield a null row when an OPTIONAL MATCH has no results
- test OPTIONAL MATCH scenarios

## Testing
- `npm test`