### PR TITLE
Fix parsing of negative numbers

### DIFF
--- a/packages/core/src/parser/CypherParser.ts
+++ b/packages/core/src/parser/CypherParser.ts
@@ -222,7 +222,7 @@ function tokenize(input: string): Token[] {
       i += str[0].length;
       continue;
     }
-    const num = /^\d+(?:\.\d+)?/.exec(rest);
+    const num = /^-?\d+(?:\.\d+)?/.exec(rest);
     if (num) {
       tokens.push({ type: 'number', value: num[0] });
       i += num[0].length;

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -590,3 +590,12 @@ runOnAdapters('single hop incoming match without labels', async engine => {
   const expected = ['Alice-The Matrix', 'Alice-John Wick', 'Bob-John Wick'];
   assert.deepStrictEqual(out.sort(), expected.sort());
 });
+
+runOnAdapters('negative numeric literals parsed correctly', async engine => {
+  let node;
+  for await (const row of engine.run('CREATE (n:Neg {val:-5}) RETURN n')) node = row.n;
+  assert.strictEqual(node.properties.val, -5);
+  const out = [];
+  for await (const row of engine.run('MATCH (n:Neg) WHERE n.val < -1 RETURN n')) out.push(row.n);
+  assert.strictEqual(out.length, 1);
+});


### PR DESCRIPTION
## Summary
- support negative numeric literals in tokenizer
- add e2e test covering negative numbers

## Testing
- `npm run build`
- `npm test --silent`