### PR TITLE
Add <> support in WHERE clauses

### DIFF
--- a/packages/core/src/parser/CypherParser.ts
+++ b/packages/core/src/parser/CypherParser.ts
@@ -61,7 +61,7 @@ export type WhereClause =
   | {
       type: 'Condition';
       left: Expression;
-      operator: '=' | '>' | '>=' | '<' | '<=';
+      operator: '=' | '>' | '>=' | '<' | '<=' | '<>';
       right: Expression;
     }
   | { type: 'And'; left: WhereClause; right: WhereClause }
@@ -548,8 +548,10 @@ class Parser {
       }
       const left = this.parseValue();
       const opTok = this.consume('punct');
-      let op: '=' | '>' | '>=' | '<' | '<=' = opTok.value as any;
-      if (opTok.value === '>' && this.optional('punct', '=')) {
+      let op: '=' | '>' | '>=' | '<' | '<=' | '<>' = opTok.value as any;
+      if (opTok.value === '<' && this.optional('punct', '>')) {
+        op = '<>';
+      } else if (opTok.value === '>' && this.optional('punct', '=')) {
         op = '>=';
       } else if (opTok.value === '<' && this.optional('punct', '=')) {
         op = '<=';

--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -91,6 +91,8 @@ function evalWhere(
           return (l as any) < (r as any);
         case '<=':
           return (l as any) <= (r as any);
+        case '<>':
+          return l !== r;
         default:
           throw new Error('Unknown operator');
       }

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -341,6 +341,12 @@ runOnAdapters('match with WHERE using NOT', async engine => {
   assert.strictEqual(out.length, 2);
 });
 
+runOnAdapters('match with WHERE not equals operator', async engine => {
+  const out = [];
+  for await (const row of engine.run('MATCH (n:Person) WHERE n.name <> "Alice" RETURN n')) out.push(row.n);
+  assert.strictEqual(out.length, 2);
+});
+
 runOnAdapters('FOREACH create multiple nodes', async engine => {
   for await (const _ of engine.run('FOREACH x IN [1,2,3] CREATE (n:Batch)')) {}
   const out = [];


### PR DESCRIPTION
## Summary
- support `<>` operator in parser and execution
- test not-equals filtering in e2e suite

## Testing
- `npm test`