### PR TITLE
Add RETURN DISTINCT support

### DIFF
--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -326,6 +326,18 @@ export function logicalToPhysical(
           }
         }
 
+        if (plan.distinct) {
+          const seen = new Set<string>();
+          const uniq: typeof rows = [];
+          for (const r of rows) {
+            const key = JSON.stringify(r.row);
+            if (seen.has(key)) continue;
+            seen.add(key);
+            uniq.push(r);
+          }
+          rows.splice(0, rows.length, ...uniq);
+        }
+
         if (plan.orderBy) {
           rows.sort((a, b) => {
             if (a.order === b.order) return 0;
@@ -701,6 +713,17 @@ export function logicalToPhysical(
           const varsStart = new Map(vars);
           varsStart.set(plan.start.variable, s);
           await traverse(s, 0, varsStart);
+        }
+        if (plan.distinct) {
+          const seen = new Set<string>();
+          const uniq: typeof rows = [];
+          for (const r of rows) {
+            const key = JSON.stringify(r.row);
+            if (seen.has(key)) continue;
+            seen.add(key);
+            uniq.push(r);
+          }
+          rows.splice(0, rows.length, ...uniq);
         }
         if (plan.orderBy) {
           rows.sort((a, b) => {

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -623,3 +623,10 @@ runOnAdapters('negative numeric literals parsed correctly', async engine => {
   for await (const row of engine.run('MATCH (n:Neg) WHERE n.val < -1 RETURN n')) out.push(row.n);
   assert.strictEqual(out.length, 1);
 });
+
+runOnAdapters('RETURN DISTINCT removes duplicates', async engine => {
+  const q = 'MATCH (p:Person)-[:ACTED_IN]->(m) RETURN DISTINCT p';
+  const out = [];
+  for await (const row of engine.run(q)) out.push(row.p.properties.name);
+  assert.deepStrictEqual(out.sort(), ['Alice', 'Bob']);
+});


### PR DESCRIPTION
## Summary
- add RETURN DISTINCT syntax to parser tokenizer
- parse DISTINCT option in RETURN clauses
- implement deduplication logic for distinct results
- cover RETURN DISTINCT in e2e tests

## Testing
- `npm test`