### PR TITLE
Support parameterized skip/limit

### DIFF
--- a/packages/core/src/parser/CypherParser.ts
+++ b/packages/core/src/parser/CypherParser.ts
@@ -13,8 +13,8 @@ export interface MatchReturnQuery {
   where?: WhereClause;
   returnItems: ReturnItem[];
   orderBy?: { expression: Expression; direction?: 'ASC' | 'DESC' }[];
-  skip?: number;
-  limit?: number;
+  skip?: Expression;
+  limit?: Expression;
 }
 
 export interface CreateQuery {
@@ -169,8 +169,8 @@ export interface MatchChainQuery {
   }[];
   returnItems: ReturnItem[];
   orderBy?: { expression: Expression; direction?: 'ASC' | 'DESC' }[];
-  skip?: number;
-  limit?: number;
+  skip?: Expression;
+  limit?: Expression;
 }
 
 export type CypherAST =
@@ -508,8 +508,8 @@ class Parser {
   private parseReturnClause(): {
     items: ReturnItem[];
     orderBy?: { expression: Expression; direction?: 'ASC' | 'DESC' }[];
-    skip?: number;
-    limit?: number;
+    skip?: Expression;
+    limit?: Expression;
   } {
     this.consume('keyword', 'RETURN');
     const items: ReturnItem[] = [];
@@ -540,15 +540,15 @@ class Parser {
         if (!this.optional('punct', ',')) break;
       }
     }
-    let skip: number | undefined;
+    let skip: Expression | undefined;
     if (this.current()?.value === 'SKIP') {
       this.consume('keyword', 'SKIP');
-      skip = Number(this.consume('number').value);
+      skip = this.parseValue();
     }
-    let limit: number | undefined;
+    let limit: Expression | undefined;
     if (this.current()?.value === 'LIMIT') {
       this.consume('keyword', 'LIMIT');
-      limit = Number(this.consume('number').value);
+      limit = this.parseValue();
     }
     return { items, orderBy, skip, limit };
   }

--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -348,9 +348,10 @@ export function logicalToPhysical(
           });
         }
 
-        const start = plan.skip ?? 0;
+        const start = plan.skip ? Number(evalExpr(plan.skip, vars, params)) : 0;
         let end = rows.length;
-        if (plan.limit !== undefined) end = Math.min(end, start + plan.limit);
+        if (plan.limit !== undefined)
+          end = Math.min(end, start + Number(evalExpr(plan.limit, vars, params)));
         if (rows.length === 0 && plan.optional) {
           vars.delete(plan.variable);
           const row: Record<string, unknown> = {};
@@ -742,9 +743,10 @@ export function logicalToPhysical(
             return 0;
           });
         }
-        const startIdx = plan.skip ?? 0;
+        const startIdx = plan.skip ? Number(evalExpr(plan.skip, vars, params)) : 0;
         let end = rows.length;
-        if (plan.limit !== undefined) end = Math.min(end, startIdx + plan.limit);
+        if (plan.limit !== undefined)
+          end = Math.min(end, startIdx + Number(evalExpr(plan.limit, vars, params)));
         for (let i = startIdx; i < end; i++) {
           yield rows[i].row;
         }

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -529,6 +529,20 @@ runOnAdapters('RETURN multiple expressions with aliases', async engine => {
   assert.deepStrictEqual(out, ['The Matrix-1999', 'John Wick-2014']);
 });
 
+runOnAdapters('LIMIT with parameter', async engine => {
+  const q = 'MATCH (n:Person) RETURN n.name AS name ORDER BY name LIMIT $lim';
+  const out = [];
+  for await (const row of engine.run(q, { lim: 2 })) out.push(row.name);
+  assert.deepStrictEqual(out, ['Alice', 'Bob']);
+});
+
+runOnAdapters('SKIP with parameter', async engine => {
+  const q = 'MATCH (n:Person) RETURN n.name AS name ORDER BY name SKIP $s';
+  const out = [];
+  for await (const row of engine.run(q, { s: 1 })) out.push(row.name);
+  assert.deepStrictEqual(out, ['Bob', 'Carol']);
+});
+
 runOnAdapters('MATCH with parameter property', async engine => {
   const q = 'MATCH (n:Person {name:$name}) RETURN n';
   const out = [];


### PR DESCRIPTION
## Summary
- test LIMIT and SKIP with parameters
- allow expressions for skip and limit in parser
- evaluate skip/limit expressions when executing

## Testing
- `npm test --silent`