### PR TITLE
Fix MatchChain WHERE support

### DIFF
--- a/packages/core/src/parser/CypherParser.ts
+++ b/packages/core/src/parser/CypherParser.ts
@@ -171,6 +171,7 @@ export interface MatchChainQuery {
   orderBy?: { expression: Expression; direction?: 'ASC' | 'DESC' }[];
   skip?: number;
   limit?: number;
+  where?: WhereClause;
 }
 
 export type CypherAST =
@@ -648,6 +649,11 @@ class Parser {
       });
       current = next;
     }
+    let where: WhereClause | undefined;
+    if (this.current()?.value === 'WHERE') {
+      this.consume('keyword', 'WHERE');
+      where = this.parseWhereClause();
+    }
     const ret = this.parseReturnClause();
     if (!ret.items.length) throw new Error('Parse error: RETURN required');
     return {
@@ -658,6 +664,7 @@ class Parser {
         properties: start.properties,
       },
       hops,
+      where,
       returnItems: ret.items,
       orderBy: ret.orderBy,
       skip: ret.skip,

--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -658,6 +658,7 @@ export function logicalToPhysical(
           varsLocal: Map<string, any>
         ): Promise<void> => {
           if (hop >= plan.hops.length) {
+            if (plan.where && !evalWhere(plan.where, varsLocal, params)) return;
             const row: Record<string, unknown> = {};
             const aliasVars = new Map(varsLocal);
             plan.returnItems.forEach((item, idx) => {

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -639,6 +639,14 @@ runOnAdapters('undirected single hop match', async engine => {
   assert.deepStrictEqual(out.sort(), expected.sort());
 });
 
+runOnAdapters('single hop match with WHERE', async engine => {
+  const q = 'MATCH (p:Person)-[:ACTED_IN]->(m:Movie) WHERE m.title = "John Wick" RETURN p, m';
+  const out = [];
+  for await (const row of engine.run(q)) out.push(`${row.p.properties.name}-${row.m.properties.title}`);
+  const expected = ['Alice-John Wick', 'Bob-John Wick'];
+  assert.deepStrictEqual(out.sort(), expected.sort());
+});
+
 runOnAdapters('negative numeric literals parsed correctly', async engine => {
   let node;
   for await (const row of engine.run('CREATE (n:Neg {val:-5}) RETURN n')) node = row.n;


### PR DESCRIPTION
## Summary
- add WHERE clause support for `MatchChain` queries
- ensure WHERE filtering works in physical plan
- test matching a relationship chain with a WHERE clause

## Testing
- `npm test`