### PR TITLE
Fix optional match aggregation default result

### DIFF
--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -300,10 +300,16 @@ export function logicalToPhysical(
         }
 
         if (hasAgg) {
+          if (
+            groups.size === 0 &&
+            plan.returnItems.every(item => isAgg(item.expression))
+          ) {
+            groups.set('__empty__', { row: {}, aggs: [] });
+          }
           for (const group of groups.values()) {
             plan.returnItems.forEach((item, idx) => {
               if (!isAgg(item.expression)) return;
-              const agg = group.aggs[idx];
+              const agg = group.aggs[idx] ?? { count: 0, sum: 0 };
               let val: any;
               switch (item.expression.type) {
                 case 'Count':

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -572,6 +572,18 @@ runOnAdapters('COUNT aggregation', async engine => {
   assert.strictEqual(out[0], 2);
 });
 
+runOnAdapters('COUNT on empty result returns 0', async engine => {
+  const out = [];
+  for await (const row of engine.run('MATCH (n:Missing) RETURN COUNT(n) AS cnt')) out.push(row.cnt);
+  assert.deepStrictEqual(out, [0]);
+});
+
+runOnAdapters('OPTIONAL MATCH with COUNT returns 0', async engine => {
+  const out = [];
+  for await (const row of engine.run('OPTIONAL MATCH (n:Missing) RETURN COUNT(n) AS cnt')) out.push(row.cnt);
+  assert.deepStrictEqual(out, [0]);
+});
+
 runOnAdapters('SUM aggregation', async engine => {
   const out = [];
   for await (const row of engine.run('MATCH (m:Movie) RETURN SUM(m.released)')) out.push(row.value);


### PR DESCRIPTION
## Summary
- handle COUNT aggregations when no matches are found
- test OPTIONAL MATCH count and empty aggregation cases

## Testing
- `npm run build`
- `npm test`