### PR TITLE
Support CREATE relationship between existing nodes

### DIFF
--- a/packages/core/src/parser/CypherParser.ts
+++ b/packages/core/src/parser/CypherParser.ts
@@ -89,10 +89,12 @@ export interface CreateRelQuery {
   relType: string;
   relProperties?: Record<string, unknown>;
   start: {
+    variable: string;
     labels?: string[];
     properties?: Record<string, unknown>;
   };
   end: {
+    variable: string;
     labels?: string[];
     properties?: Record<string, unknown>;
   };
@@ -834,8 +836,8 @@ class Parser {
         relVariable: relVar,
         relType,
         relProperties: relProps,
-        start: { labels: start.labels, properties: start.properties },
-        end: { labels: end.labels, properties: end.properties },
+        start: { variable: start.variable, labels: start.labels, properties: start.properties },
+        end: { variable: end.variable, labels: end.labels, properties: end.properties },
         returnVariable: ret,
       };
     }

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -239,6 +239,17 @@ runOnAdapters('create relationship and return nodes', async engine => {
   }
 });
 
+runOnAdapters('CREATE relationship between existing nodes', async (engine, adapter) => {
+  const script =
+    'MATCH (p:Person {name:"Alice"}) RETURN p; ' +
+    'MATCH (m:Movie {title:"John Wick"}) RETURN m; ' +
+    'CREATE (p)-[r:ACTED_IN]->(m) RETURN r';
+  let rel;
+  for await (const row of engine.run(script)) if (row.r) rel = row.r;
+  assert.strictEqual(rel.startNode, 1);
+  assert.strictEqual(rel.endNode, 4);
+});
+
 runOnAdapters('update node property multiple times', async engine => {
   const script = 'MATCH (n:Person {name:"Alice"}) SET n.age = 1 RETURN n; MATCH (n:Person {name:"Alice"}) SET n.age = 2 RETURN n';
   let last;


### PR DESCRIPTION
## Summary
- allow `CREATE (a)-[r:T]->(b)` to reuse already bound nodes
- add e2e coverage for creating relationships with previously matched nodes

## Testing
- `npm test`