### PR TITLE
Add parentheses support in WHERE clauses

### DIFF
--- a/packages/core/src/parser/CypherParser.ts
+++ b/packages/core/src/parser/CypherParser.ts
@@ -454,6 +454,12 @@ class Parser {
       this.consume('punct', ']');
       return { type: 'Literal', value: arr };
     }
+    if (tok.type === 'punct' && tok.value === '(') {
+      this.pos++;
+      const expr = this.parseValue();
+      this.consume('punct', ')');
+      return expr;
+    }
     if (tok.type === 'punct' && tok.value === '*') {
       this.pos++;
       return { type: 'All' };
@@ -572,6 +578,12 @@ class Parser {
       if (this.current()?.value === 'NOT') {
         this.consume('keyword', 'NOT');
         return { type: 'Not', clause: parseNot() };
+      }
+      if (this.current()?.value === '(') {
+        this.consume('punct', '(');
+        const inner = this.parseWhereClause();
+        this.consume('punct', ')');
+        return inner;
       }
       const left = this.parseValue();
       if (this.current()?.value === 'IN') {

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -354,6 +354,14 @@ runOnAdapters('match with WHERE IN list', async engine => {
   assert.deepStrictEqual(out.sort(), ['Alice', 'Bob']);
 });
 
+runOnAdapters('WHERE clause with parentheses', async engine => {
+  const q =
+    'MATCH (n:Person) WHERE (n.name = "Alice" OR n.name = "Bob") RETURN n';
+  const out = [];
+  for await (const row of engine.run(q)) out.push(row.n.properties.name);
+  assert.deepStrictEqual(out.sort(), ['Alice', 'Bob']);
+});
+
 runOnAdapters('FOREACH create multiple nodes', async engine => {
   for await (const _ of engine.run('FOREACH x IN [1,2,3] CREATE (n:Batch)')) {}
   const out = [];


### PR DESCRIPTION
## Summary
- add an e2e test covering parentheses in WHERE
- support parenthesized expressions in parser for values and WHERE clauses

## Testing
- `npm test`