### PR TITLE
Support setting multiple properties in MATCH SET

### DIFF
--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -551,9 +551,13 @@ export function logicalToPhysical(
             }
             vars.set(plan.variable, rel);
             if (plan.where && !evalWhere(plan.where, vars, params)) continue;
-            const val = evalExpr(plan.value, vars, params);
-            await adapter.updateRelationshipProperties(rel.id, { [plan.property]: val });
-            rel.properties[plan.property] = val;
+            const updates: Record<string, any> = {};
+            for (const [prop, expr] of Object.entries(plan.updates)) {
+              const val = evalExpr(expr, vars, params);
+              updates[prop] = val;
+              rel.properties[prop] = val;
+            }
+            await adapter.updateRelationshipProperties(rel.id, updates);
             if (plan.returnVariable) {
               yield { [plan.variable]: rel };
             }
@@ -565,9 +569,13 @@ export function logicalToPhysical(
           if (bound && (!plan.labels || plan.labels.length === 0) && !plan.properties) {
             const node = bound;
             if (!plan.where || evalWhere(plan.where, vars, params)) {
-              const val = evalExpr(plan.value, vars, params);
-              await adapter.updateNodeProperties(node.id, { [plan.property]: val });
-              node.properties[plan.property] = val;
+              const updates: Record<string, any> = {};
+              for (const [prop, expr] of Object.entries(plan.updates)) {
+                const val = evalExpr(expr, vars, params);
+                updates[prop] = val;
+                node.properties[prop] = val;
+              }
+              await adapter.updateNodeProperties(node.id, updates);
               if (plan.returnVariable) {
                 yield { [plan.variable]: node };
               }
@@ -586,9 +594,13 @@ export function logicalToPhysical(
               if (!ok) continue;
               vars.set(plan.variable, node);
               if (plan.where && !evalWhere(plan.where, vars, params)) continue;
-              const val = evalExpr(plan.value, vars, params);
-              await adapter.updateNodeProperties(node.id, { [plan.property]: val });
-              node.properties[plan.property] = val;
+              const updates: Record<string, any> = {};
+              for (const [prop, expr] of Object.entries(plan.updates)) {
+                const val = evalExpr(expr, vars, params);
+                updates[prop] = val;
+                node.properties[prop] = val;
+              }
+              await adapter.updateNodeProperties(node.id, updates);
               if (plan.returnVariable) {
                 yield { [plan.variable]: node };
               }

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -90,6 +90,13 @@ runOnAdapters('SET updates node property', async engine => {
   }
 });
 
+runOnAdapters('SET multiple properties', async engine => {
+  for await (const row of engine.run('MATCH (n:Person {name:"Bob"}) SET n.age = 31, n.flag = true RETURN n')) {
+    assert.strictEqual(row.n.properties.age, 31);
+    assert.strictEqual(row.n.properties.flag, true);
+  }
+});
+
 runOnAdapters('DELETE removes node', async engine => {
   for await (const _ of engine.run('MATCH (n:Person {name:"Carol"}) DELETE n')) {}
   const out = [];


### PR DESCRIPTION
## Summary
- allow MATCH SET clauses to update multiple properties
- update physical plan to handle updates map
- add regression test covering multiple property assignments

## Testing
- `npm test`