### PR TITLE
Add id() function support

### DIFF
--- a/packages/core/src/parser/CypherParser.ts
+++ b/packages/core/src/parser/CypherParser.ts
@@ -53,6 +53,7 @@ export type Expression =
   | { type: 'Add'; left: Expression; right: Expression }
   | { type: 'Sub'; left: Expression; right: Expression }
   | { type: 'Nodes'; variable: string }
+  | { type: 'Id'; variable: string }
   | { type: 'Count'; expression: Expression | null; distinct?: boolean }
   | { type: 'Sum'; expression: Expression; distinct?: boolean }
   | { type: 'Min'; expression: Expression; distinct?: boolean }
@@ -501,6 +502,13 @@ class Parser {
         const inner = this.parseIdentifier();
         this.consume('punct', ')');
         return { type: 'Nodes', variable: inner };
+      }
+      if (tok.value === 'id') {
+        this.pos++;
+        this.consume('punct', '(');
+        const inner = this.parseIdentifier();
+        this.consume('punct', ')');
+        return { type: 'Id', variable: inner };
       }
       const variable = this.parseIdentifier();
       if (this.optional('punct', '.')) {

--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -40,6 +40,10 @@ function evalExpr(
     }
     case 'Nodes':
       return vars.get(expr.variable);
+    case 'Id': {
+      const rec = vars.get(expr.variable) as NodeRecord | RelRecord | undefined;
+      return rec ? rec.id : undefined;
+    }
     case 'All':
       return Object.fromEntries(vars.entries());
     default:

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -781,3 +781,16 @@ runOnAdapters('RETURN star with relationship chain', async engine => {
   assert.strictEqual(out[0].m.properties.title, 'John Wick');
   assert.strictEqual(out[0].r.type, 'ACTED_IN');
 });
+runOnAdapters('id() function returns node id', async engine => {
+  const out = [];
+  for await (const row of engine.run('MATCH (n:Person {name:"Alice"}) RETURN id(n) AS id'))
+    out.push(row.id);
+  assert.deepStrictEqual(out, [1]);
+});
+
+runOnAdapters('id() on relationship returns rel id', async engine => {
+  const out = [];
+  const q = 'MATCH ()-[r:ACTED_IN {role:"Neo"}]->() RETURN id(r) AS id';
+  for await (const row of engine.run(q)) out.push(row.id);
+  assert.deepStrictEqual(out, [7]);
+});


### PR DESCRIPTION
## Summary
- expand expression types to include `Id`
- allow parsing of `id(variable)` expressions
- evaluate `Id` expressions to return node or relationship id
- test id() support for nodes and relationships

## Testing
- `npm test`