### PR TITLE
Fix null literal handling

### DIFF
--- a/packages/core/src/parser/CypherParser.ts
+++ b/packages/core/src/parser/CypherParser.ts
@@ -46,7 +46,7 @@ export interface MatchDeleteQuery {
 }
 
 export type Expression =
-  | { type: 'Literal'; value: string | number | boolean | unknown[] }
+  | { type: 'Literal'; value: string | number | boolean | unknown[] | null }
   | { type: 'Property'; variable: string; property: string }
   | { type: 'Variable'; name: string }
   | { type: 'Parameter'; name: string }
@@ -402,6 +402,10 @@ class Parser {
       this.pos++;
       return Number(tok.value);
     }
+    if (tok.type === 'identifier' && tok.value.toLowerCase() === 'null') {
+      this.pos++;
+      return null;
+    }
     if (tok.type === 'punct' && tok.value === '[') {
       this.pos++;
       const arr: unknown[] = [];
@@ -445,6 +449,10 @@ class Parser {
     if (tok.type === 'number') {
       this.pos++;
       return { type: 'Literal', value: Number(tok.value) };
+    }
+    if (tok.type === 'identifier' && tok.value.toLowerCase() === 'null') {
+      this.pos++;
+      return { type: 'Literal', value: null };
     }
     if (tok.type === 'punct' && tok.value === '[') {
       this.pos++;

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -781,3 +781,12 @@ runOnAdapters('RETURN star with relationship chain', async engine => {
   assert.strictEqual(out[0].m.properties.title, 'John Wick');
   assert.strictEqual(out[0].r.type, 'ACTED_IN');
 });
+
+runOnAdapters('null property values supported', async engine => {
+  let node;
+  for await (const row of engine.run('CREATE (n:NullTest {x:null}) RETURN n')) node = row.n;
+  assert.strictEqual(node.properties.x, null);
+  const out = [];
+  for await (const row of engine.run('MATCH (n:NullTest {x:null}) RETURN n')) out.push(row.n);
+  assert.strictEqual(out.length, 1);
+});


### PR DESCRIPTION
## Summary
- support `null` literal in parser
- add regression test for null property values

## Testing
- `npm test`