### PR TITLE
Add WHERE support for relationship chain

### DIFF
--- a/packages/core/src/parser/CypherParser.ts
+++ b/packages/core/src/parser/CypherParser.ts
@@ -174,6 +174,7 @@ export interface MatchChainQuery {
       properties?: Record<string, unknown>;
     };
   }[];
+  where?: WhereClause;
   returnItems: ReturnItem[];
   orderBy?: { expression: Expression; direction?: 'ASC' | 'DESC' }[];
   skip?: Expression;
@@ -677,6 +678,11 @@ class Parser {
       });
       current = next;
     }
+    let where: WhereClause | undefined;
+    if (this.current()?.value === 'WHERE') {
+      this.consume('keyword', 'WHERE');
+      where = this.parseWhereClause();
+    }
     const ret = this.parseReturnClause();
     if (!ret.items.length) throw new Error('Parse error: RETURN required');
     return {
@@ -687,6 +693,7 @@ class Parser {
         properties: start.properties,
       },
       hops,
+      where,
       returnItems: ret.items,
       orderBy: ret.orderBy,
       skip: ret.skip,

--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -763,6 +763,7 @@ export function logicalToPhysical(
           varsLocal: Map<string, any>
         ): Promise<void> => {
           if (hop >= plan.hops.length) {
+            if (plan.where && !evalWhere(plan.where, varsLocal, params)) return;
             const row: Record<string, unknown> = {};
             const aliasVars = new Map(varsLocal);
             plan.returnItems.forEach((item, idx) => {

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -781,3 +781,11 @@ runOnAdapters('RETURN star with relationship chain', async engine => {
   assert.strictEqual(out[0].m.properties.title, 'John Wick');
   assert.strictEqual(out[0].r.type, 'ACTED_IN');
 });
+
+runOnAdapters('single hop chain with WHERE filter', async engine => {
+  const q =
+    'MATCH (p:Person)-[:ACTED_IN]->(m:Movie) WHERE m.released > 2000 RETURN m';
+  const out = [];
+  for await (const row of engine.run(q)) out.push(row.m.properties.title);
+  assert.deepStrictEqual(out.sort(), ['John Wick', 'John Wick'].sort());
+});


### PR DESCRIPTION
## Summary
- add `where` property to `MatchChain` queries
- parse optional `WHERE` clauses for relationship chains
- evaluate `WHERE` during chain traversal
- test chain queries with `WHERE` filter

## Testing
- `npm test`