### PR TITLE
Fix zero-length path matches

### DIFF
--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -62,7 +62,7 @@ async function findPath(
   while (queue.length > 0) {
     const path = queue.shift()!;
     const last = path[path.length - 1];
-    if (last === endId) {
+    if (last === endId && path.length > 1) {
       const nodes: NodeRecord[] = [];
       for (const id of path) {
         const n = await adapter.getNodeById(id);

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -414,6 +414,15 @@ runOnAdapters('FOREACH over path nodes sets property', async engine => {
   assert.strictEqual(out.length, 3);
 });
 
+runOnAdapters('variable length path excludes zero length', async engine => {
+  const out = [];
+  for await (const row of engine.run('MATCH p=(a)-[*]->(b) RETURN p')) out.push(row.p);
+  assert.ok(out.length > 0);
+  for (const p of out) {
+    assert.ok(Array.isArray(p) && p.length >= 2);
+  }
+});
+
 runOnAdapters('multi-hop ->()-> chain returns final node', async engine => {
   const out = [];
   const q =


### PR DESCRIPTION
## Summary
- add regression test for variable length path to ensure at least one hop
- ignore zero-length matches in `findPath`

## Testing
- `npm test`