### PR TITLE
Support top-level RETURN queries

### DIFF
--- a/packages/core/src/logical/LogicalPlan.ts
+++ b/packages/core/src/logical/LogicalPlan.ts
@@ -13,12 +13,14 @@ import {
   UnwindQuery,
   UnionQuery,
   CallQuery,
+  ReturnQuery,
 } from '../parser/CypherParser';
 
 // Logical plan nodes mirror the parsed AST for now but live in a separate layer
 // so that optimizers can operate on them before physical compilation.
 export type LogicalPlan =
   | LogicalMatchReturn
+  | LogicalReturn
   | LogicalCreate
   | LogicalMerge
   | LogicalMatchDelete
@@ -45,6 +47,7 @@ export type LogicalForeach = ForeachQuery;
 export type LogicalUnwind = UnwindQuery;
 export type LogicalUnion = UnionQuery;
 export type LogicalCall = CallQuery;
+export type LogicalReturn = ReturnQuery;
 
 export function astToLogical(ast: CypherAST): LogicalPlan {
   // In this MVP the AST shape already matches the logical plan

--- a/packages/core/src/parser/CypherParser.ts
+++ b/packages/core/src/parser/CypherParser.ts
@@ -45,6 +45,15 @@ export interface MatchDeleteQuery {
   where?: WhereClause;
 }
 
+export interface ReturnQuery {
+  type: 'Return';
+  returnItems: ReturnItem[];
+  orderBy?: { expression: Expression; direction?: 'ASC' | 'DESC' }[];
+  skip?: Expression;
+  limit?: Expression;
+  distinct?: boolean;
+}
+
 export type Expression =
   | { type: 'Literal'; value: string | number | boolean | unknown[] }
   | { type: 'Property'; variable: string; property: string }
@@ -183,6 +192,7 @@ export interface MatchChainQuery {
 
 export type CypherAST =
   | MatchReturnQuery
+  | ReturnQuery
   | CreateQuery
   | MergeQuery
   | MatchDeleteQuery
@@ -293,6 +303,7 @@ class Parser {
     if (tok.value === 'FOREACH') return this.parseForeach();
     if (tok.value === 'UNWIND') return this.parseUnwind();
     if (tok.value === 'CALL') return this.parseCall();
+    if (tok.value === 'RETURN') return this.parseReturnOnly();
     throw new Error('Parse error: unsupported query');
   }
 
@@ -581,6 +592,18 @@ class Parser {
       limit = this.parseValue();
     }
     return { items, orderBy, skip, limit, distinct };
+  }
+
+  private parseReturnOnly(): ReturnQuery {
+    const ret = this.parseReturnClause();
+    return {
+      type: 'Return',
+      returnItems: ret.items,
+      orderBy: ret.orderBy,
+      skip: ret.skip,
+      limit: ret.limit,
+      distinct: ret.distinct,
+    };
   }
 
   private parseWhereClause(): WhereClause {

--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -960,6 +960,37 @@ export function logicalToPhysical(
         }
         break;
       }
+      case 'Return': {
+        const aliasFor = (item: typeof plan.returnItems[number], idx: number): string => {
+          if (item.alias) return item.alias;
+          if (item.expression.type === 'Variable') return item.expression.name;
+          return plan.returnItems.length === 1 ? 'value' : `value${idx}`;
+        };
+        const row: Record<string, unknown> = {};
+        const aliasVars = new Map(vars);
+        plan.returnItems.forEach((item, idx) => {
+          if (item.expression.type === 'All') {
+            for (const [k, v] of vars.entries()) {
+              row[k] = v;
+              aliasVars.set(k, v);
+            }
+          } else {
+            const val = evalExpr(item.expression, vars, params);
+            const alias = aliasFor(item, idx);
+            row[alias] = val;
+            if (item.alias) aliasVars.set(item.alias, val);
+          }
+        });
+        let include = true;
+        const skip = plan.skip ? Number(evalExpr(plan.skip, vars, params)) : 0;
+        let limit = plan.limit ? Number(evalExpr(plan.limit, vars, params)) : 1;
+        if (skip > 0) include = false;
+        if (include && limit > 0) {
+          yield row;
+          limit--;
+        }
+        break;
+      }
       case 'Call': {
         const innerPlans = plan.subquery.map(q =>
           logicalToPhysical(astToLogical(q), adapter)

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -810,3 +810,9 @@ runOnAdapters('id() on relationship returns rel id', async engine => {
   for await (const row of engine.run(q)) out.push(row.id);
   assert.deepStrictEqual(out, [7]);
 });
+
+runOnAdapters('standalone RETURN expression', async engine => {
+  const out = [];
+  for await (const row of engine.run('RETURN 42 AS val')) out.push(row.val);
+  assert.deepStrictEqual(out, [42]);
+});

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -51,7 +51,15 @@ test('parseMany splits semicolon separated statements', () => {
   assert.strictEqual(q2.type, 'MatchReturn');
 });
 
-// Invalid query should throw
+test('parse top-level RETURN', () => {
+  const ast = parse('RETURN 1 AS one');
+  assert.strictEqual(ast.type, 'Return');
+  assert.deepStrictEqual(ast.returnItems, [
+    { expression: { type: 'Literal', value: 1 }, alias: 'one' }
+  ]);
+});
+
+// Invalid query should still throw
 test('parse unsupported query throws', () => {
-  assert.throws(() => parse('RETURN n'), /Parse error/);
+  assert.throws(() => parse('FOO'));
 });


### PR DESCRIPTION
## Summary
- allow parsing and executing RETURN-only statements
- adjust logical plan types for the new query
- add e2e test showing `RETURN 42` works
- update parser tests

## Testing
- `npm test`