### PR TITLE
Fix COUNT DISTINCT * handling

### DIFF
--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -148,6 +148,21 @@ function evalProps(
   return out;
 }
 
+function serializeVars(vars: Map<string, any>): string {
+  const obj: Record<string, unknown> = {};
+  const entries = Array.from(vars.entries()).sort(([a], [b]) =>
+    a.localeCompare(b)
+  );
+  for (const [k, v] of entries) {
+    if (v && typeof v === 'object' && 'id' in v) {
+      obj[k] = (v as any).id;
+    } else {
+      obj[k] = v;
+    }
+  }
+  return JSON.stringify(obj);
+}
+
 function hasAgg(expr: Expression): boolean {
   switch (expr.type) {
     case 'Count':
@@ -223,7 +238,10 @@ function updateAggState(
     case 'Count': {
       const val = state.expr ? evalExpr(state.expr, vars, params) : null;
       if (state.distinct) {
-        const key = JSON.stringify(val);
+        const key =
+          state.expr === null
+            ? serializeVars(vars)
+            : JSON.stringify(val);
         if (!state.values.has(key)) {
           state.values.add(key);
           state.count++;

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -641,6 +641,13 @@ runOnAdapters('COUNT DISTINCT aggregation', async engine => {
   assert.strictEqual(out[0], 3);
 });
 
+runOnAdapters('COUNT DISTINCT star counts rows', async engine => {
+  const out = [];
+  const q = 'MATCH (p:Person) RETURN COUNT(DISTINCT *) AS cnt';
+  for await (const row of engine.run(q)) out.push(row.cnt);
+  assert.strictEqual(out[0], 3);
+});
+
 runOnAdapters('SUM aggregation', async engine => {
   const out = [];
   for await (const row of engine.run('MATCH (m:Movie) RETURN SUM(m.released)')) out.push(row.value);


### PR DESCRIPTION
## Summary
- add failing e2e for `COUNT(DISTINCT *)`
- fix aggregator logic to properly handle DISTINCT when expression is `*`

## Testing
- `npm test`