### PR TITLE
Add support for IS NULL / IS NOT NULL

### DIFF
--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -93,7 +93,7 @@ function evalWhere(
   switch (where.type) {
     case 'Condition': {
       const l = evalExpr(where.left, vars, params);
-      const r = evalExpr(where.right, vars, params);
+      const r = where.right !== undefined ? evalExpr(where.right, vars, params) : undefined;
       switch (where.operator) {
         case '=':
           return l === r;
@@ -109,6 +109,10 @@ function evalWhere(
           return l !== r;
         case 'IN':
           return Array.isArray(r) && r.includes(l);
+        case 'IS NULL':
+          return l === null || l === undefined;
+        case 'IS NOT NULL':
+          return l !== null && l !== undefined;
         default:
           throw new Error('Unknown operator');
       }

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -624,6 +624,20 @@ runOnAdapters('WHERE clause with parameter', async engine => {
   assert.strictEqual(out[0].properties.title, 'John Wick');
 });
 
+runOnAdapters('WHERE IS NULL matches missing property', async engine => {
+  const out = [];
+  for await (const row of engine.run('MATCH (n:Person) WHERE n.age IS NULL RETURN n')) out.push(row.n);
+  assert.strictEqual(out.length, 3);
+});
+
+runOnAdapters('WHERE IS NOT NULL matches existing property', async engine => {
+  for await (const _ of engine.run('MATCH (n:Person {name:"Bob"}) SET n.age = 30')) {}
+  const out = [];
+  for await (const row of engine.run('MATCH (n:Person) WHERE n.age IS NOT NULL RETURN n')) out.push(row.n);
+  assert.strictEqual(out.length, 1);
+  assert.strictEqual(out[0].properties.name, 'Bob');
+});
+
 runOnAdapters('SET property using parameter', async engine => {
   const q = 'MATCH (n:Person {name:"Bob"}) SET n.age = $age RETURN n';
   let node;


### PR DESCRIPTION
## Summary
- add `IS` keyword and support for `null` literal in parser
- extend `WhereClause` to allow `IS NULL` and `IS NOT NULL`
- implement evaluation logic for new operators
- add e2e tests for `WHERE ... IS NULL` and `WHERE ... IS NOT NULL`

## Testing
- `npm test`