### PR TITLE
Support null literals in parser

### DIFF
--- a/packages/core/src/parser/CypherParser.ts
+++ b/packages/core/src/parser/CypherParser.ts
@@ -56,7 +56,7 @@ export interface ReturnQuery {
 }
 
 export type Expression =
-  | { type: 'Literal'; value: string | number | boolean | unknown[] }
+  | { type: 'Literal'; value: string | number | boolean | unknown[] | null }
   | { type: 'Property'; variable: string; property: string }
   | { type: 'Variable'; name: string }
   | { type: 'Parameter'; name: string }
@@ -440,8 +440,12 @@ class Parser {
       this.pos++;
       return { __param: tok.value };
     }
-    if (tok.type === 'identifier' && (tok.value === 'true' || tok.value === 'false')) {
+    if (
+      tok.type === 'identifier' &&
+      (tok.value === 'true' || tok.value === 'false' || tok.value === 'null')
+    ) {
       this.pos++;
+      if (tok.value === 'null') return null;
       return tok.value === 'true';
     }
     throw new Error('Unexpected value');
@@ -495,8 +499,9 @@ class Parser {
       return { type: 'Parameter', name: tok.value };
     }
     if (tok.type === 'identifier') {
-      if (tok.value === 'true' || tok.value === 'false') {
+      if (tok.value === 'true' || tok.value === 'false' || tok.value === 'null') {
         this.pos++;
+        if (tok.value === 'null') return { type: 'Literal', value: null };
         return { type: 'Literal', value: tok.value === 'true' };
       }
       const func = tok.value.toLowerCase();

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -854,3 +854,14 @@ runOnAdapters('standalone RETURN expression', async engine => {
   for await (const row of engine.run('RETURN 42 AS val')) out.push(row.val);
   assert.deepStrictEqual(out, [42]);
 });
+
+runOnAdapters('NULL literal handled in create and match', async engine => {
+  let node;
+  for await (const row of engine.run('CREATE (n:NullTest {v:null}) RETURN n'))
+    node = row.n;
+  assert.strictEqual(node.properties.v, null);
+  const out = [];
+  for await (const row of engine.run('MATCH (n:NullTest) WHERE n.v = null RETURN n'))
+    out.push(row.n);
+  assert.strictEqual(out.length, 1);
+});


### PR DESCRIPTION
## Summary
- add support for `null` literals in the parser
- add regression e2e test for using null values

## Testing
- `npm test`