### PR TITLE
Support unary minus expressions

### DIFF
--- a/packages/core/src/parser/CypherParser.ts
+++ b/packages/core/src/parser/CypherParser.ts
@@ -470,6 +470,11 @@ class Parser {
       this.pos++;
       return { type: 'Literal', value: Number(tok.value) };
     }
+    if (tok.type === 'punct' && tok.value === '-') {
+      this.pos++;
+      const expr = this.parseValueAtom();
+      return { type: 'Sub', left: { type: 'Literal', value: 0 }, right: expr };
+    }
     if (tok.type === 'punct' && tok.value === '[') {
       this.pos++;
       const arr: unknown[] = [];

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -854,3 +854,10 @@ runOnAdapters('standalone RETURN expression', async engine => {
   for await (const row of engine.run('RETURN 42 AS val')) out.push(row.val);
   assert.deepStrictEqual(out, [42]);
 });
+
+runOnAdapters('unary minus on property expression', async engine => {
+  const out = [];
+  const q = 'MATCH (m:Movie {title:"The Matrix"}) RETURN -m.released AS neg';
+  for await (const row of engine.run(q)) out.push(row.neg);
+  assert.deepStrictEqual(out, [-1999]);
+});


### PR DESCRIPTION
## Summary
- allow parser to handle unary minus prefix
- verify unary minus through new e2e test

## Testing
- `npm test`