### PR TITLE
Fix parameter handling in match chains

### DIFF
--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -948,7 +948,7 @@ export function logicalToPhysical(
           let ok = true;
           if (plan.start.properties) {
             for (const [k, v] of Object.entries(plan.start.properties)) {
-              if (node.properties[k] !== v) {
+              if (node.properties[k] !== evalPropValue(v, vars, params)) {
                 ok = false;
                 break;
               }

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -631,6 +631,14 @@ runOnAdapters('SET property using parameter', async engine => {
   assert.strictEqual(node.properties.age, 55);
 });
 
+runOnAdapters('chain match with parameter property', async engine => {
+  const q = 'MATCH (p:Person {name:$name})-[:ACTED_IN]->(m:Movie) RETURN m';
+  const out = [];
+  for await (const row of engine.run(q, { name: 'Alice' }))
+    out.push(row.m.properties.title);
+  assert.deepStrictEqual(out.sort(), ['John Wick', 'The Matrix']);
+});
+
 runOnAdapters('COUNT aggregation', async engine => {
   const out = [];
   for await (const row of engine.run('MATCH (m:Movie) RETURN COUNT(m)')) out.push(row.value);


### PR DESCRIPTION
## Summary
- handle parameter evaluation for match chain start node properties
- test match chain with parameterized property

## Testing
- `npm test`