### PR TITLE
Support relationship merge without variable

### DIFF
--- a/packages/core/src/parser/CypherParser.ts
+++ b/packages/core/src/parser/CypherParser.ts
@@ -104,7 +104,7 @@ export interface MatchSetQuery {
 
 export interface CreateRelQuery {
   type: 'CreateRel';
-  relVariable: string;
+  relVariable?: string;
   relType: string;
   relProperties?: Record<string, unknown>;
   start: {
@@ -122,7 +122,7 @@ export interface CreateRelQuery {
 
 export interface MergeRelQuery {
   type: 'MergeRel';
-  relVariable: string;
+  relVariable?: string;
   relType: string;
   relProperties?: Record<string, unknown>;
   startVariable: string;
@@ -290,6 +290,10 @@ class Parser {
 
   private current(): Token | undefined {
     return this.tokens[this.pos];
+  }
+
+  private lookahead(n = 1): Token | undefined {
+    return this.tokens[this.pos + n];
   }
 
   private consume(type: Token['type'], value?: string): Token {
@@ -927,8 +931,14 @@ class Parser {
     if (this.current()?.value === '-') {
       this.consume('punct', '-');
       this.consume('punct', '[');
-      const relVar = this.parseIdentifier();
-      this.consume('punct', ':');
+      let relVar: string;
+      if (this.current()?.type === 'identifier' && this.lookahead()?.value === ':') {
+        relVar = this.parseIdentifier();
+        this.consume('punct', ':');
+      } else {
+        relVar = this.genAnonVar();
+        this.consume('punct', ':');
+      }
       const relType = this.parseIdentifier();
       let relProps: Record<string, unknown> | undefined;
       if (this.optional('punct', '{')) {
@@ -987,8 +997,14 @@ class Parser {
     if (this.current()?.value === '-') {
       this.consume('punct', '-');
       this.consume('punct', '[');
-      const relVar = this.parseIdentifier();
-      this.consume('punct', ':');
+      let relVar: string;
+      if (this.current()?.type === 'identifier' && this.lookahead()?.value === ':') {
+        relVar = this.parseIdentifier();
+        this.consume('punct', ':');
+      } else {
+        relVar = this.genAnonVar();
+        this.consume('punct', ':');
+      }
       const relType = this.parseIdentifier();
       let relProps: Record<string, unknown> | undefined;
       if (this.optional('punct', '{')) {

--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -779,7 +779,7 @@ export function logicalToPhysical(
           endNode.id,
           evalProps(plan.relProperties ?? {}, vars, params)
         );
-        if (plan.returnVariable) {
+        if (plan.returnVariable && plan.relVariable) {
           vars.set(plan.relVariable, rel);
           yield { [plan.relVariable]: rel };
         }
@@ -824,7 +824,7 @@ export function logicalToPhysical(
           );
           created = true;
         }
-        vars.set(plan.relVariable, existing);
+        if (plan.relVariable) vars.set(plan.relVariable, existing);
         if (created && plan.onCreateSet && adapter.updateRelationshipProperties) {
           for (const [k, expr] of Object.entries(plan.onCreateSet)) {
             const val = evalExpr(expr, vars, params);
@@ -839,7 +839,7 @@ export function logicalToPhysical(
             existing.properties[k] = val;
           }
         }
-        if (plan.returnVariable) {
+        if (plan.returnVariable && plan.relVariable) {
           yield { [plan.relVariable]: existing };
         }
         break;


### PR DESCRIPTION
## Summary
- allow MERGE/CREATE relationship patterns to omit relationship variable
- expose parser lookahead helper to detect tokens
- handle optional relationship variables in physical plan
- test MERGE of relationship without variable

## Testing
- `npm test`