### PR TITLE
Add basic WITH clause support

### DIFF
--- a/packages/core/src/logical/LogicalPlan.ts
+++ b/packages/core/src/logical/LogicalPlan.ts
@@ -9,6 +9,7 @@ import {
   MergeRelQuery,
   MatchPathQuery,
   MatchChainQuery,
+  WithQuery,
   ForeachQuery,
   UnwindQuery,
   UnionQuery,
@@ -29,6 +30,7 @@ export type LogicalPlan =
   | LogicalMergeRel
   | LogicalMatchPath
   | LogicalMatchChain
+  | LogicalWith
   | LogicalForeach
   | LogicalUnwind
   | LogicalUnion
@@ -43,6 +45,7 @@ export type LogicalCreateRel = CreateRelQuery;
 export type LogicalMergeRel = MergeRelQuery;
 export type LogicalMatchPath = MatchPathQuery;
 export type LogicalMatchChain = MatchChainQuery;
+export type LogicalWith = WithQuery;
 export type LogicalForeach = ForeachQuery;
 export type LogicalUnwind = UnwindQuery;
 export type LogicalUnion = UnionQuery;

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -912,3 +912,11 @@ runOnAdapters('NULL literal handled in create and match', async engine => {
     out.push(row.n);
   assert.strictEqual(out.length, 1);
 });
+
+runOnAdapters('WITH passes variable to subsequent MATCH', async engine => {
+  const q =
+    'MATCH (p:Person {name:"Alice"}) WITH p MATCH (p)-[:ACTED_IN]->(m) RETURN m.title AS title';
+  const out = [];
+  for await (const row of engine.run(q)) out.push(row.title);
+  assert.deepStrictEqual(out.sort(), ['John Wick', 'The Matrix']);
+});


### PR DESCRIPTION
## Summary
- add `WithQuery` to parser and logical plan
- implement `WITH` clause parsing
- support `With` execution in physical plan
- bind existing start nodes in `MatchChain`
- test WITH usage in e2e suite

## Testing
- `npm test`