### PR TITLE
Add string matching operators in WHERE

### DIFF
--- a/packages/core/src/parser/CypherParser.ts
+++ b/packages/core/src/parser/CypherParser.ts
@@ -84,7 +84,10 @@ export type WhereClause =
         | '<>'
         | 'IN'
         | 'IS NULL'
-        | 'IS NOT NULL';
+        | 'IS NOT NULL'
+        | 'STARTS WITH'
+        | 'ENDS WITH'
+        | 'CONTAINS';
       right?: Expression;
     }
   | { type: 'And'; left: WhereClause; right: WhereClause }
@@ -238,7 +241,7 @@ function tokenize(input: string): Token[] {
       i += ws[0].length;
       continue;
     }
-    const keyword = /^(MATCH|RETURN|CREATE|MERGE|SET|DELETE|WHERE|FOREACH|IN|ON|UNWIND|AS|ORDER|BY|LIMIT|SKIP|OPTIONAL|WITH|CALL|UNION|ALL|AND|OR|NOT|ASC|DESC|DISTINCT|IS)\b/i.exec(rest);
+    const keyword = /^(MATCH|RETURN|CREATE|MERGE|SET|DELETE|WHERE|FOREACH|IN|ON|UNWIND|AS|ORDER|BY|LIMIT|SKIP|OPTIONAL|WITH|CALL|UNION|ALL|AND|OR|NOT|ASC|DESC|DISTINCT|IS|STARTS|ENDS|CONTAINS)\b/i.exec(rest);
     if (keyword) {
       tokens.push({ type: 'keyword', value: keyword[1].toUpperCase() });
       i += keyword[0].length;
@@ -658,6 +661,23 @@ class Parser {
         this.consume('keyword', 'IN');
         const right = this.parseValue();
         return { type: 'Condition', left, operator: 'IN', right };
+      }
+      if (this.current()?.value === 'STARTS') {
+        this.consume('keyword', 'STARTS');
+        this.consume('keyword', 'WITH');
+        const right = this.parseValue();
+        return { type: 'Condition', left, operator: 'STARTS WITH', right };
+      }
+      if (this.current()?.value === 'ENDS') {
+        this.consume('keyword', 'ENDS');
+        this.consume('keyword', 'WITH');
+        const right = this.parseValue();
+        return { type: 'Condition', left, operator: 'ENDS WITH', right };
+      }
+      if (this.current()?.value === 'CONTAINS') {
+        this.consume('keyword', 'CONTAINS');
+        const right = this.parseValue();
+        return { type: 'Condition', left, operator: 'CONTAINS', right };
       }
       if (this.current()?.value === 'IS') {
         this.consume('keyword', 'IS');

--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -113,6 +113,12 @@ function evalWhere(
           return l === null || l === undefined;
         case 'IS NOT NULL':
           return l !== null && l !== undefined;
+        case 'STARTS WITH':
+          return typeof l === 'string' && typeof r === 'string' && l.startsWith(r);
+        case 'ENDS WITH':
+          return typeof l === 'string' && typeof r === 'string' && l.endsWith(r);
+        case 'CONTAINS':
+          return typeof l === 'string' && typeof r === 'string' && l.includes(r);
         default:
           throw new Error('Unknown operator');
       }

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -411,6 +411,27 @@ runOnAdapters('WHERE clause with parentheses', async engine => {
   assert.deepStrictEqual(out.sort(), ['Alice', 'Bob']);
 });
 
+runOnAdapters('match with WHERE STARTS WITH', async engine => {
+  const q = 'MATCH (n:Person) WHERE n.name STARTS WITH "A" RETURN n';
+  const out = [];
+  for await (const row of engine.run(q)) out.push(row.n.properties.name);
+  assert.deepStrictEqual(out, ['Alice']);
+});
+
+runOnAdapters('match with WHERE ENDS WITH', async engine => {
+  const q = 'MATCH (n:Person) WHERE n.name ENDS WITH "b" RETURN n';
+  const out = [];
+  for await (const row of engine.run(q)) out.push(row.n.properties.name);
+  assert.deepStrictEqual(out, ['Bob']);
+});
+
+runOnAdapters('match with WHERE CONTAINS', async engine => {
+  const q = 'MATCH (n:Person) WHERE n.name CONTAINS "ar" RETURN n';
+  const out = [];
+  for await (const row of engine.run(q)) out.push(row.n.properties.name);
+  assert.deepStrictEqual(out, ['Carol']);
+});
+
 runOnAdapters('FOREACH create multiple nodes', async engine => {
   for await (const _ of engine.run('FOREACH x IN [1,2,3] CREATE (n:Batch)')) {}
   const out = [];


### PR DESCRIPTION
## Summary
- support `STARTS WITH`, `ENDS WITH`, and `CONTAINS` operators in WHERE clauses
- add e2e tests for these new operators

## Testing
- `npm run build`
- `npm test`