### PR TITLE
Fix boolean literal case insensitivity

### DIFF
--- a/packages/core/src/parser/CypherParser.ts
+++ b/packages/core/src/parser/CypherParser.ts
@@ -453,13 +453,13 @@ class Parser {
       this.pos++;
       return { __param: tok.value };
     }
-    if (
-      tok.type === 'identifier' &&
-      (tok.value === 'true' || tok.value === 'false' || tok.value === 'null')
-    ) {
-      this.pos++;
-      if (tok.value === 'null') return null;
-      return tok.value === 'true';
+    if (tok.type === 'identifier') {
+      const lowered = tok.value.toLowerCase();
+      if (lowered === 'true' || lowered === 'false' || lowered === 'null') {
+        this.pos++;
+        if (lowered === 'null') return null;
+        return lowered === 'true';
+      }
     }
     throw new Error('Unexpected value');
   }
@@ -512,14 +512,11 @@ class Parser {
       return { type: 'Parameter', name: tok.value };
     }
     if (tok.type === 'identifier') {
-      if (tok.value === 'true' || tok.value === 'false' || tok.value === 'null') {
+      const lowered = tok.value.toLowerCase();
+      if (lowered === 'true' || lowered === 'false' || lowered === 'null') {
         this.pos++;
-        if (tok.value === 'null') return { type: 'Literal', value: null };
-        return { type: 'Literal', value: tok.value === 'true' };
-      }
-      if (tok.value === 'null') {
-        this.pos++;
-        return { type: 'Literal', value: null };
+        if (lowered === 'null') return { type: 'Literal', value: null };
+        return { type: 'Literal', value: lowered === 'true' };
       }
       const func = tok.value.toLowerCase();
       if (['count', 'sum', 'min', 'max', 'avg'].includes(func)) {

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -912,3 +912,8 @@ runOnAdapters('NULL literal handled in create and match', async engine => {
     out.push(row.n);
   assert.strictEqual(out.length, 1);
 });
+runOnAdapters('boolean literals case insensitive', async engine => {
+  const out = [];
+  for await (const row of engine.run('RETURN TRUE AS t, FALSE AS f, NULL AS n')) out.push(row);
+  assert.deepStrictEqual(out, [{ t: true, f: false, n: null }]);
+});


### PR DESCRIPTION
## Summary
- add failing e2e test for TRUE/FALSE/NULL literals
- make parser treat boolean and NULL literals in a case-insensitive manner

## Testing
- `npm test`
