### PR TITLE
Support comma separated MATCH patterns

### DIFF
--- a/packages/core/src/logical/LogicalPlan.ts
+++ b/packages/core/src/logical/LogicalPlan.ts
@@ -1,6 +1,7 @@
 import {
   CypherAST,
   MatchReturnQuery,
+  MatchMultiReturnQuery,
   CreateQuery,
   MergeQuery,
   MatchDeleteQuery,
@@ -21,6 +22,7 @@ import {
 // so that optimizers can operate on them before physical compilation.
 export type LogicalPlan =
   | LogicalMatchReturn
+  | LogicalMatchMultiReturn
   | LogicalReturn
   | LogicalCreate
   | LogicalMerge
@@ -37,6 +39,7 @@ export type LogicalPlan =
   | LogicalCall;
 
 export type LogicalMatchReturn = MatchReturnQuery;
+export type LogicalMatchMultiReturn = MatchMultiReturnQuery;
 export type LogicalCreate = CreateQuery;
 export type LogicalMerge = MergeQuery;
 export type LogicalMatchDelete = MatchDeleteQuery;

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -879,6 +879,13 @@ runOnAdapters('undirected single hop match', async engine => {
   assert.deepStrictEqual(out.sort(), expected.sort());
 });
 
+runOnAdapters('MATCH with multiple node patterns', async engine => {
+  const q = 'MATCH (p:Person), (m:Movie) RETURN p.name AS name, m.title AS title';
+  const out = [];
+  for await (const row of engine.run(q)) out.push(`${row.name}-${row.title}`);
+  assert.strictEqual(out.length, 6);
+});
+
 runOnAdapters('negative numeric literals parsed correctly', async engine => {
   let node;
   for await (const row of engine.run('CREATE (n:Neg {val:-5}) RETURN n')) node = row.n;


### PR DESCRIPTION
## Summary
- add a new `MatchMultiReturn` AST type
- extend parser to handle `MATCH (a), (b)` style queries
- implement physical planner execution for multi-pattern MATCH
- update logical plan types
- add e2e test for multiple node patterns

## Testing
- `npm run build`
- `npm test`