### PR TITLE
Add MERGE relationship node pattern support

### DIFF
--- a/packages/core/src/parser/CypherParser.ts
+++ b/packages/core/src/parser/CypherParser.ts
@@ -129,8 +129,16 @@ export interface MergeRelQuery {
   relVariable?: string;
   relType: string;
   relProperties?: Record<string, unknown>;
-  startVariable: string;
-  endVariable: string;
+  start: {
+    variable?: string;
+    labels?: string[];
+    properties?: Record<string, unknown>;
+  };
+  end: {
+    variable?: string;
+    labels?: string[];
+    properties?: Record<string, unknown>;
+  };
   onCreateSet?: Record<string, Expression>;
   onMatchSet?: Record<string, Expression>;
   returnVariable?: string;
@@ -1136,14 +1144,13 @@ class Parser {
       }
       const ret = this.parseReturnVariable();
       if (ret && ret !== relVar) throw new Error('Parse error: return variable mismatch');
-      if (!start.variable || !end.variable) throw new Error('Parse error: node variables required');
       return {
         type: 'MergeRel',
         relVariable: relVar,
         relType,
         relProperties: relProps,
-        startVariable: start.variable,
-        endVariable: end.variable,
+        start: { variable: start.variable, labels: start.labels, properties: start.properties },
+        end: { variable: end.variable, labels: end.labels, properties: end.properties },
         returnVariable: ret,
         onCreateSet: onCreate,
         onMatchSet: onMatch,

--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -814,18 +814,57 @@ export function logicalToPhysical(
         break;
       }
       case 'MergeRel': {
-        if (!adapter.scanRelationships || !adapter.createRelationship)
+        if (
+          !adapter.scanRelationships ||
+          !adapter.createRelationship ||
+          !adapter.findNode ||
+          !adapter.createNode
+        )
           throw new Error('Adapter does not support MERGE');
-        const startNode = vars.get(plan.startVariable) as NodeRecord | undefined;
-        const endNode = vars.get(plan.endVariable) as NodeRecord | undefined;
-        if (!startNode || !endNode)
-          throw new Error('MergeRel requires bound start and end variables');
+
+        let startNode: NodeRecord | null | undefined =
+          plan.start.variable
+            ? (vars.get(plan.start.variable) as NodeRecord | undefined)
+            : undefined;
+        if (!startNode) {
+          startNode = await adapter.findNode(
+            plan.start.labels ?? [],
+            evalProps(plan.start.properties ?? {}, vars, params)
+          );
+          if (!startNode) {
+            startNode = await adapter.createNode(
+              plan.start.labels ?? [],
+              evalProps(plan.start.properties ?? {}, vars, params)
+            );
+          }
+          if (plan.start.variable) vars.set(plan.start.variable, startNode);
+        }
+
+        let endNode: NodeRecord | null | undefined =
+          plan.end.variable
+            ? (vars.get(plan.end.variable) as NodeRecord | undefined)
+            : undefined;
+        if (!endNode) {
+          endNode = await adapter.findNode(
+            plan.end.labels ?? [],
+            evalProps(plan.end.properties ?? {}, vars, params)
+          );
+          if (!endNode) {
+            endNode = await adapter.createNode(
+              plan.end.labels ?? [],
+              evalProps(plan.end.properties ?? {}, vars, params)
+            );
+          }
+          if (plan.end.variable) vars.set(plan.end.variable, endNode);
+        }
+        const sNode = startNode as NodeRecord;
+        const eNode = endNode as NodeRecord;
         let existing: RelRecord | null = null;
         for await (const rel of adapter.scanRelationships()) {
           if (
             rel.type === plan.relType &&
-            rel.startNode === startNode.id &&
-            rel.endNode === endNode.id
+            rel.startNode === sNode.id &&
+            rel.endNode === eNode.id
           ) {
             let ok = true;
             if (plan.relProperties) {
@@ -846,8 +885,8 @@ export function logicalToPhysical(
         if (!existing) {
           existing = await adapter.createRelationship(
             plan.relType,
-            startNode.id,
-            endNode.id,
+            sNode.id,
+            eNode.id,
             evalProps(plan.relProperties ?? {}, vars, params)
           );
           created = true;

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -262,6 +262,17 @@ runOnAdapters('merge relationship without variable', async (engine, adapter) => 
   assert.strictEqual(likes[0].endNode, 3);
 });
 
+runOnAdapters('merge relationship creates nodes from pattern', async (engine, adapter) => {
+  const q = 'MERGE (p:Person {name:"Frank"})-[r:LIKES]->(g:Genre {name:"Action"}) RETURN r';
+  let rel;
+  for await (const row of engine.run(q)) if (row.r) rel = row.r;
+  assert.ok(rel);
+  const frank = await adapter.findNode(['Person'], { name: 'Frank' });
+  assert.ok(frank);
+  assert.strictEqual(rel.startNode, frank.id);
+  assert.strictEqual(rel.endNode, 6);
+});
+
 
 runOnAdapters('relationship deleted is gone', async engine => {
   for await (const _ of engine.run('MATCH ()-[r:ACTED_IN {role:"Buddy"}]->() DELETE r')) {}

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -41,8 +41,17 @@ test('parse MERGE (a)-[r:REL]->(b) RETURN r', () => {
   const ast = parse('MERGE (a)-[r:REL]->(b) RETURN r');
   assert.strictEqual(ast.type, 'MergeRel');
   assert.strictEqual(ast.relType, 'REL');
-  assert.strictEqual(ast.startVariable, 'a');
-  assert.strictEqual(ast.endVariable, 'b');
+  assert.strictEqual(ast.start.variable, 'a');
+  assert.strictEqual(ast.end.variable, 'b');
+});
+
+test('parse MERGE (a:Person {name:"A"})-[r:REL]->(b:Person {name:"B"}) RETURN r', () => {
+  const ast = parse('MERGE (a:Person {name:"A"})-[r:REL]->(b:Person {name:"B"}) RETURN r');
+  assert.strictEqual(ast.type, 'MergeRel');
+  assert.strictEqual(ast.start.labels[0], 'Person');
+  assert.strictEqual(ast.start.properties.name, 'A');
+  assert.strictEqual(ast.end.labels[0], 'Person');
+  assert.strictEqual(ast.end.properties.name, 'B');
 });
 
 test('parseMany splits semicolon separated statements', () => {


### PR DESCRIPTION
## Summary
- allow MERGE of relationships when node patterns include labels/properties
- update parser and physical plan for new `MergeRel` fields
- add new e2e test covering MERGE relationship with node creation
- adjust parser tests

## Testing
- `npm run build`
- `npm test`