### PR TITLE
Add length() function support

### DIFF
--- a/packages/core/src/parser/CypherParser.ts
+++ b/packages/core/src/parser/CypherParser.ts
@@ -70,6 +70,7 @@ export type Expression =
   | { type: 'Max'; expression: Expression; distinct?: boolean }
   | { type: 'Avg'; expression: Expression; distinct?: boolean }
   | { type: 'Collect'; expression: Expression; distinct?: boolean }
+  | { type: 'Length'; variable: string }
   | { type: 'All' };
 
 export type WhereClause =
@@ -559,6 +560,13 @@ class Parser {
         const inner = this.parseIdentifier();
         this.consume('punct', ')');
         return { type: 'Nodes', variable: inner };
+      }
+      if (tok.value === 'length') {
+        this.pos++;
+        this.consume('punct', '(');
+        const inner = this.parseIdentifier();
+        this.consume('punct', ')');
+        return { type: 'Length', variable: inner };
       }
       if (tok.value === 'id') {
         this.pos++;

--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -40,6 +40,16 @@ function evalExpr(
     }
     case 'Nodes':
       return vars.get(expr.variable);
+    case 'Length': {
+      const val = vars.get(expr.variable);
+      if (Array.isArray(val)) {
+        return val.length > 0 ? val.length - 1 : 0;
+      }
+      if (typeof val === 'string') {
+        return val.length;
+      }
+      return undefined;
+    }
     case 'Id': {
       const rec = vars.get(expr.variable) as NodeRecord | RelRecord | undefined;
       return rec ? rec.id : undefined;

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -475,6 +475,14 @@ runOnAdapters('variable length path can return end node', async engine => {
   assert.deepStrictEqual(out, ['Action']);
 });
 
+runOnAdapters('length() on path returns hop count', async engine => {
+  const q =
+    'MATCH p=(a:Person {name:"Alice"})-[*]->(g:Genre {name:"Action"}) RETURN length(p) AS len';
+  const out = [];
+  for await (const row of engine.run(q)) out.push(row.len);
+  assert.deepStrictEqual(out, [2]);
+});
+
 runOnAdapters('multi-hop ->()-> chain returns final node', async engine => {
   const out = [];
   const q =


### PR DESCRIPTION
## Summary
- support the Cypher `length()` function for paths
- test `length()` with a new e2e case

## Testing
- `npm test`