### PR TITLE
Add support for top-level WITH

### DIFF
--- a/packages/core/src/parser/CypherParser.ts
+++ b/packages/core/src/parser/CypherParser.ts
@@ -238,7 +238,7 @@ export interface MatchChainQuery {
 
 export interface WithQuery {
   type: 'With';
-  source: MatchReturnQuery | MatchChainQuery;
+  source: MatchReturnQuery | MatchChainQuery | ReturnQuery;
   next: CypherAST;
 }
 
@@ -366,6 +366,19 @@ class Parser {
     if (tok.value === 'FOREACH') return this.parseForeach();
     if (tok.value === 'UNWIND') return this.parseUnwind();
     if (tok.value === 'CALL') return this.parseCall();
+    if (tok.value === 'WITH') {
+      const withClause = this.parseWithClause();
+      const source: ReturnQuery = {
+        type: 'Return',
+        returnItems: withClause.items,
+        orderBy: withClause.orderBy,
+        skip: withClause.skip,
+        limit: withClause.limit,
+        distinct: withClause.distinct,
+      };
+      const next = this.parse();
+      return { type: 'With', source, next };
+    }
     if (tok.value === 'RETURN') return this.parseReturnOnly();
     throw new Error('Parse error: unsupported query');
   }

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -982,3 +982,8 @@ runOnAdapters('WITH after relationship chain returns nodes', async engine => {
   for await (const row of engine.run(q)) out.push(row.title);
   assert.deepStrictEqual(out.sort(), ['John Wick', 'John Wick', 'The Matrix']);
 });
+runOnAdapters('top-level WITH returns value', async engine => {
+  const out = [];
+  for await (const row of engine.run('WITH 1 AS x RETURN x')) out.push(row.x);
+  assert.deepStrictEqual(out, [1]);
+});


### PR DESCRIPTION
## Summary
- allow `WITH` to start a query
- expand `WithQuery` to accept RETURN clauses
- test top-level WITH in e2e suite

## Testing
- `npm test`