### PR TITLE
Add variable property matching support

### DIFF
--- a/packages/core/src/parser/CypherParser.ts
+++ b/packages/core/src/parser/CypherParser.ts
@@ -456,7 +456,14 @@ class Parser {
       }
       const key = this.parseIdentifier();
       this.consume('punct', ':');
-      props[key] = this.parseLiteralValue();
+      const expr = this.parseValue();
+      if (expr.type === 'Literal') {
+        props[key] = expr.value;
+      } else if (expr.type === 'Parameter') {
+        props[key] = { __param: expr.name };
+      } else {
+        props[key] = expr;
+      }
       first = false;
       if (this.current()?.value === '}') {
         break;

--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -149,8 +149,13 @@ function evalPropValue(
   vars: Map<string, any>,
   params: Record<string, any>
 ): any {
-  if (val && typeof val === 'object' && '__param' in val) {
-    return params[(val as any).__param];
+  if (val && typeof val === 'object') {
+    if ('__param' in val) {
+      return params[(val as any).__param];
+    }
+    if ('type' in val) {
+      return evalExpr(val as Expression, vars, params);
+    }
   }
   return val;
 }

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -982,3 +982,11 @@ runOnAdapters('WITH after relationship chain returns nodes', async engine => {
   for await (const row of engine.run(q)) out.push(row.title);
   assert.deepStrictEqual(out.sort(), ['John Wick', 'John Wick', 'The Matrix']);
 });
+runOnAdapters('match property with WITH variable', async engine => {
+  const q =
+    'MATCH (a:Person {name:"Alice"}) WITH a.name AS n MATCH (p:Person {name:n}) RETURN p';
+  const out = [];
+  for await (const row of engine.run(q)) out.push(row.p);
+  assert.strictEqual(out.length, 1);
+  assert.strictEqual(out[0].properties.name, 'Alice');
+});


### PR DESCRIPTION
## Summary
- support expressions in property maps so variables from WITH clauses can be used
- evaluate property expressions when matching or creating
- add e2e test verifying variable-based property match

## Testing
- `npm test`