### PR TITLE
Add WHERE filtering to WITH clauses

### DIFF
--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -1454,6 +1454,9 @@ export function logicalToPhysical(
             const alias = aliasFor(item, idx);
             local.set(alias, (row as any)[alias]);
           });
+          if (plan.where && !evalWhere(plan.where, local, params)) {
+            continue;
+          }
           for await (const out of right(local, params)) {
             yield out;
           }

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -1023,3 +1023,10 @@ runOnAdapters('top-level WITH returns value', async engine => {
   for await (const row of engine.run('WITH 1 AS x RETURN x')) out.push(row.x);
   assert.deepStrictEqual(out, [1]);
 });
+runOnAdapters('WITH with WHERE filters rows', async engine => {
+  const q = 'MATCH (p:Person) WITH p WHERE p.name = "Alice" RETURN p';
+  const out = [];
+  for await (const row of engine.run(q)) out.push(row.p);
+  assert.strictEqual(out.length, 1);
+  assert.strictEqual(out[0].properties.name, 'Alice');
+});


### PR DESCRIPTION
## Summary
- support `WHERE` in `WITH` clauses
- test `WITH` clause filtering

## Testing
- `npm test`