### PR TITLE
Fix optional MATCH for multi-pattern clauses

### DIFF
--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -673,6 +673,7 @@ export function logicalToPhysical(
 
           const pat = plan.patterns[idx];
           let usedIndex = false;
+          let matched = false;
           if (
             pat.labels &&
             pat.labels.length > 0 &&
@@ -690,6 +691,7 @@ export function logicalToPhysical(
               for await (const node of adapter.indexLookup(label, prop, value)) {
                 const nextVars = new Map(varsLocal);
                 nextVars.set(pat.variable, node);
+                matched = true;
                 await traverse(idx + 1, nextVars);
               }
               usedIndex = true;
@@ -710,8 +712,14 @@ export function logicalToPhysical(
               }
               const nextVars = new Map(varsLocal);
               nextVars.set(pat.variable, node);
+              matched = true;
               await traverse(idx + 1, nextVars);
             }
+          }
+          if (!matched && plan.optional) {
+            const nextVars = new Map(varsLocal);
+            nextVars.set(pat.variable, undefined);
+            await traverse(idx + 1, nextVars);
           }
         };
 

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -657,6 +657,15 @@ runOnAdapters('OPTIONAL MATCH existing node returns it', async engine => {
   assert.strictEqual(out[0].properties.name, 'Alice');
 });
 
+runOnAdapters('OPTIONAL MATCH multiple patterns returns partial row', async engine => {
+  const q = 'OPTIONAL MATCH (p:Person {name:"Missing"}), (m:Movie {title:"The Matrix"}) RETURN p, m';
+  const out = [];
+  for await (const row of engine.run(q)) out.push(row);
+  assert.strictEqual(out.length, 1);
+  assert.strictEqual(out[0].m.properties.title, 'The Matrix');
+  assert.strictEqual(out[0].p, undefined);
+});
+
 runOnAdapters('ORDER BY with SKIP and LIMIT', async engine => {
   const q = 'MATCH (n:Person) RETURN n.name AS name ORDER BY n.name SKIP 1 LIMIT 1';
   const out = [];


### PR DESCRIPTION
## Summary
- handle optional semantics for `MatchMultiReturn`
- test OPTIONAL MATCH with multiple patterns

## Testing
- `npm test`