### PR TITLE
Fix parsing of id alias in WITH

### DIFF
--- a/packages/core/src/parser/CypherParser.ts
+++ b/packages/core/src/parser/CypherParser.ts
@@ -589,7 +589,10 @@ class Parser {
         return { type: 'Literal', value: null };
       }
       const func = tok.value.toLowerCase();
-      if (['count', 'sum', 'min', 'max', 'avg', 'collect'].includes(func)) {
+      if (
+        ['count', 'sum', 'min', 'max', 'avg', 'collect'].includes(func) &&
+        this.lookahead()?.value === '('
+      ) {
         this.pos++;
         this.consume('punct', '(');
         const distinct = this.optional('keyword', 'DISTINCT') !== null;
@@ -609,21 +612,21 @@ class Parser {
           | 'Collect';
         return { type, expression: expr, distinct } as Expression;
       }
-      if (tok.value === 'nodes') {
+      if (tok.value === 'nodes' && this.lookahead()?.value === '(') {
         this.pos++;
         this.consume('punct', '(');
         const inner = this.parseIdentifier();
         this.consume('punct', ')');
         return { type: 'Nodes', variable: inner };
       }
-      if (tok.value === 'length') {
+      if (tok.value === 'length' && this.lookahead()?.value === '(') {
         this.pos++;
         this.consume('punct', '(');
         const inner = this.parseIdentifier();
         this.consume('punct', ')');
         return { type: 'Length', variable: inner };
       }
-      if (tok.value === 'id') {
+      if (tok.value === 'id' && this.lookahead()?.value === '(') {
         this.pos++;
         this.consume('punct', '(');
         const inner = this.parseIdentifier();

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -1003,6 +1003,13 @@ runOnAdapters('id() on relationship returns rel id', async engine => {
   assert.deepStrictEqual(out, [7]);
 });
 
+runOnAdapters('WITH alias named id allowed', async engine => {
+  const q = 'MATCH (n:Person {name:"Alice"}) WITH id(n) AS id RETURN id';
+  const out = [];
+  for await (const row of engine.run(q)) out.push(row.id);
+  assert.deepStrictEqual(out, [1]);
+});
+
 runOnAdapters('standalone RETURN expression', async engine => {
   const out = [];
   for await (const row of engine.run('RETURN 42 AS val')) out.push(row.val);


### PR DESCRIPTION
## Summary
- fix parser to treat `id` as a function only when followed by `(`
- test use of `id` as an alias in WITH clauses

## Testing
- `npm test --silent`