### PR TITLE
Fix WITH star variable pass-through

### DIFF
--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -1489,8 +1489,14 @@ export function logicalToPhysical(
         for await (const row of left(new Map(vars), params)) {
           const local = new Map(vars);
           plan.source.returnItems.forEach((item, idx) => {
-            const alias = aliasFor(item, idx);
-            local.set(alias, (row as any)[alias]);
+            if (item.expression.type === 'All') {
+              for (const [k, v] of Object.entries(row as any)) {
+                local.set(k, v);
+              }
+            } else {
+              const alias = aliasFor(item, idx);
+              local.set(alias, (row as any)[alias]);
+            }
           });
           if (plan.where && !evalWhere(plan.where, local, params)) {
             continue;

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -1046,3 +1046,11 @@ runOnAdapters('WITH with WHERE filters rows', async engine => {
   assert.strictEqual(out.length, 1);
   assert.strictEqual(out[0].properties.name, 'Alice');
 });
+
+runOnAdapters('WITH star passes through variables', async engine => {
+  const q = 'MATCH (p:Person {name:"Alice"}) WITH * RETURN p';
+  const out = [];
+  for await (const row of engine.run(q)) out.push(row.p);
+  assert.strictEqual(out.length, 1);
+  assert.strictEqual(out[0].properties.name, 'Alice');
+});


### PR DESCRIPTION
## Summary
- add failing e2e case for `WITH *`
- handle `WITH *` in physical plan to forward all variables

## Testing
- `npm test`