### PR TITLE
Add WHERE support for relationship chains

### DIFF
--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -1269,6 +1269,9 @@ export function logicalToPhysical(
         ): Promise<void> => {
           if (hop >= plan.hops.length) {
             const aliasVars = new Map(varsLocal);
+            if (plan.where && !evalWhere(plan.where, aliasVars, params)) {
+              return;
+            }
             if (hasAggFlag) {
               const keyParts: unknown[] = [];
               let group = null;

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -581,6 +581,14 @@ runOnAdapters('multi-hop chain length 3', async engine => {
   assert.strictEqual(out[0].properties.name, 'Thriller');
 });
 
+runOnAdapters('relationship chain with WHERE filters results', async engine => {
+  const out = [];
+  const q =
+    'MATCH (p:Person)-[:ACTED_IN]->(m:Movie) WHERE m.released > 2000 RETURN m.title AS title';
+  for await (const row of engine.run(q)) out.push(row.title);
+  assert.deepStrictEqual(out.sort(), ['John Wick', 'John Wick']);
+});
+
 runOnAdapters('return numeric addition expression', async engine => {
   const out = [];
   for await (const row of engine.run('MATCH (m:Movie) RETURN m.released+3')) out.push(row.value);


### PR DESCRIPTION
## Summary
- support WHERE clauses on relationship chain MATCH patterns
- test relationship chain filtering with WHERE

## Testing
- `npm test`