### PR TITLE
Support alias in UNWIND

### DIFF
--- a/packages/core/src/parser/CypherParser.ts
+++ b/packages/core/src/parser/CypherParser.ts
@@ -197,6 +197,7 @@ export interface UnwindQuery {
   list: unknown[] | Expression;
   variable: string;
   returnExpression: Expression;
+  returnAlias?: string;
 }
 
 export interface UnionQuery {
@@ -1394,7 +1395,11 @@ class Parser {
     const variable = this.parseIdentifier();
     this.consume('keyword', 'RETURN');
     const returnExpression = this.parseValue();
-    return { type: 'Unwind', list, variable, returnExpression };
+    let returnAlias: string | undefined;
+    if (this.optional('keyword', 'AS')) {
+      returnAlias = this.parseIdentifier();
+    }
+    return { type: 'Unwind', list, variable, returnExpression, returnAlias };
   }
 
   private parseCall(): CallQuery {

--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -1490,14 +1490,13 @@ export function logicalToPhysical(
         for (const item of items) {
           vars.set(plan.variable, item);
           const val = evalExpr(plan.returnExpression, vars, params);
-          if (
-            plan.returnExpression.type === 'Variable' &&
+          const alias =
+            plan.returnAlias ??
+            (plan.returnExpression.type === 'Variable' &&
             plan.returnExpression.name === plan.variable
-          ) {
-            yield { [plan.variable]: val };
-          } else {
-            yield { value: val };
-          }
+              ? plan.variable
+              : 'value');
+          yield { [alias]: val };
         }
         break;
       }

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -633,6 +633,12 @@ runOnAdapters('UNWIND expression on list items', async engine => {
   assert.deepStrictEqual(out.sort(), [2, 3, 4]);
 });
 
+runOnAdapters('UNWIND with return alias', async engine => {
+  const out = [];
+  for await (const row of engine.run('UNWIND [1,2,3] AS x RETURN x AS val')) out.push(row.val);
+  assert.deepStrictEqual(out.sort(), [1, 2, 3]);
+});
+
 runOnAdapters('UNWIND nodes from path', async engine => {
   const script =
     'MATCH p=(a:Person {name:"Alice"})-[*]->(g:Genre {name:"Action"}) RETURN p; ' +


### PR DESCRIPTION
## Summary
- allow aliasing return expression in `UNWIND`
- handle alias in physical plan
- test UNWIND return alias in e2e suite

## Testing
- `npm test`