### PR TITLE
Add support for inbound/undirected variable length paths

### DIFF
--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -82,7 +82,8 @@ async function findPath(
   startId: number | string,
   endId: number | string,
   minHops = 1,
-  maxHops = Infinity
+  maxHops = Infinity,
+  direction: 'out' | 'in' | 'none' = 'out'
 ): Promise<NodeRecord[] | null> {
   if (!adapter.scanRelationships || !adapter.getNodeById) {
     throw new Error('Adapter does not support path finding');
@@ -106,11 +107,22 @@ async function findPath(
     }
     if (hops >= maxHops) continue;
     for (const rel of rels) {
-      if (rel.startNode === last) {
-        const key = `${rel.endNode}:${hops + 1}`;
-        if (!visited.has(key)) {
-          visited.add(key);
-          queue.push([...path, rel.endNode]);
+      if (direction === 'out' || direction === 'none') {
+        if (rel.startNode === last) {
+          const key = `${rel.endNode}:${hops + 1}`;
+          if (!visited.has(key)) {
+            visited.add(key);
+            queue.push([...path, rel.endNode]);
+          }
+        }
+      }
+      if (direction === 'in' || direction === 'none') {
+        if (rel.endNode === last) {
+          const key = `${rel.startNode}:${hops + 1}`;
+          if (!visited.has(key)) {
+            visited.add(key);
+            queue.push([...path, rel.startNode]);
+          }
         }
       }
     }
@@ -1169,7 +1181,8 @@ export function logicalToPhysical(
               s.id,
               e.id,
               plan.minHops ?? 1,
-              plan.maxHops ?? Infinity
+              plan.maxHops ?? Infinity,
+              plan.direction ?? 'out'
             );
             if (!path) continue;
             vars.set(plan.pathVariable, path);

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -530,6 +530,22 @@ runOnAdapters('variable length path exact length', async engine => {
   assert.deepStrictEqual(out.sort(), [1, 1]);
 });
 
+runOnAdapters('variable length incoming path', async engine => {
+  const q =
+    'MATCH q=(m:Movie {title:"John Wick"})<-[*]-(a:Person {name:"Alice"}) RETURN length(q) AS len';
+  const out = [];
+  for await (const row of engine.run(q)) out.push(row.len);
+  assert.deepStrictEqual(out, [1]);
+});
+
+runOnAdapters('variable length undirected path', async engine => {
+  const q =
+    'MATCH q=(a:Person {name:"Alice"})-[*]-(b:Person {name:"Bob"}) RETURN length(q) AS len';
+  const out = [];
+  for await (const row of engine.run(q)) out.push(row.len);
+  assert.deepStrictEqual(out, [2]);
+});
+
 runOnAdapters('multi-hop ->()-> chain returns final node', async engine => {
   const out = [];
   const q =


### PR DESCRIPTION
## Summary
- extend `MatchPathQuery` with `direction`
- allow `<-` and undirected `-` variable length path syntax in parser
- enhance `findPath` to traverse relationships in all directions
- add e2e tests covering incoming and undirected variable length paths

## Testing
- `npm run build`
- `npm test`