### PR TITLE
Fix property patterns using variables

### DIFF
--- a/packages/core/src/parser/CypherParser.ts
+++ b/packages/core/src/parser/CypherParser.ts
@@ -478,7 +478,7 @@ class Parser {
       }
       const key = this.parseIdentifier();
       this.consume('punct', ':');
-      props[key] = this.parseLiteralValue();
+      props[key] = this.parseValue();
       first = false;
       if (this.current()?.value === '}') {
         break;

--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -184,8 +184,13 @@ function evalPropValue(
   vars: Map<string, any>,
   params: Record<string, any>
 ): any {
-  if (val && typeof val === 'object' && '__param' in val) {
-    return params[(val as any).__param];
+  if (val && typeof val === 'object') {
+    if ('__param' in val) {
+      return params[(val as any).__param];
+    }
+    if ('type' in val) {
+      return evalExpr(val as Expression, vars, params);
+    }
   }
   return val;
 }
@@ -977,7 +982,7 @@ export function logicalToPhysical(
             if (plan.properties) {
               let ok = true;
               for (const [k, v] of Object.entries(plan.properties)) {
-                if (rel.properties[k] !== v) {
+                if (rel.properties[k] !== evalPropValue(v, vars, params)) {
                   ok = false;
                   break;
                 }

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -1108,3 +1108,12 @@ runOnAdapters('WITH preserves variable across simple MATCH', async engine => {
   assert.strictEqual(out.length, 1);
   assert.strictEqual(out[0].properties.name, 'Alice');
 });
+
+runOnAdapters('alias used in subsequent pattern property', async engine => {
+  const q =
+    'MATCH (p:Person {name:"Alice"}) WITH p.name AS nm MATCH (n:Person {name:nm}) RETURN n';
+  const out = [];
+  for await (const row of engine.run(q)) out.push(row.n);
+  assert.strictEqual(out.length, 1);
+  assert.strictEqual(out[0].properties.name, 'Alice');
+});

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -27,14 +27,20 @@ test('parse CREATE (n:Person {name:"Alice"}) RETURN n', () => {
   const ast = parse('CREATE (n:Person {name:"Alice"}) RETURN n');
   assert.strictEqual(ast.type, 'Create');
   assert.deepStrictEqual(ast.labels, ['Person']);
-  assert.strictEqual(ast.properties.name, 'Alice');
+  assert.deepStrictEqual(ast.properties.name, {
+    type: 'Literal',
+    value: 'Alice'
+  });
 });
 
 // Merge node without return
 test('parse MERGE (n {name:"Bob"})', () => {
   const ast = parse('MERGE (n {name:"Bob"})');
   assert.strictEqual(ast.type, 'Merge');
-  assert.strictEqual(ast.properties.name, 'Bob');
+  assert.deepStrictEqual(ast.properties.name, {
+    type: 'Literal',
+    value: 'Bob'
+  });
 });
 
 test('parse MERGE (a)-[r:REL]->(b) RETURN r', () => {
@@ -49,9 +55,15 @@ test('parse MERGE (a:Person {name:"A"})-[r:REL]->(b:Person {name:"B"}) RETURN r'
   const ast = parse('MERGE (a:Person {name:"A"})-[r:REL]->(b:Person {name:"B"}) RETURN r');
   assert.strictEqual(ast.type, 'MergeRel');
   assert.strictEqual(ast.start.labels[0], 'Person');
-  assert.strictEqual(ast.start.properties.name, 'A');
+  assert.deepStrictEqual(ast.start.properties.name, {
+    type: 'Literal',
+    value: 'A'
+  });
   assert.strictEqual(ast.end.labels[0], 'Person');
-  assert.strictEqual(ast.end.properties.name, 'B');
+  assert.deepStrictEqual(ast.end.properties.name, {
+    type: 'Literal',
+    value: 'B'
+  });
 });
 
 test('parseMany splits semicolon separated statements', () => {


### PR DESCRIPTION
## Summary
- allow expressions in pattern property maps
- evaluate expression property values at runtime
- support relationship property matches with expressions
- test alias-based property lookup in pattern

## Testing
- `npm test --silent`