### PR TITLE
Fix CALL subquery alias results

### DIFF
--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -1650,10 +1650,10 @@ export function logicalToPhysical(
         const outRows: Record<string, unknown>[] = [];
         for (let i = 0; i < innerPlans.length; i++) {
           const p = innerPlans[i];
-          let idx = 0;
-          for await (const _row of p(local, params)) {
-            idx++;
+          for await (const row of p(local, params)) {
             if (i === innerPlans.length - 1) {
+              const varsWithRow = new Map(local);
+              for (const [k, v] of Object.entries(row)) varsWithRow.set(k, v);
               const out: Record<string, unknown> = {};
               plan.returnItems.forEach((item, ridx) => {
                 const alias =
@@ -1663,7 +1663,7 @@ export function logicalToPhysical(
                     : plan.returnItems.length === 1
                     ? 'value'
                     : `value${ridx}`);
-                out[alias] = evalExpr(item.expression, local, params);
+                out[alias] = evalExpr(item.expression, varsWithRow, params);
               });
               outRows.push(out);
             }

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -918,6 +918,13 @@ runOnAdapters('CALL subquery returns rows', async engine => {
   assert.strictEqual(out[0].properties.name, 'Alice');
 });
 
+runOnAdapters('CALL subquery propagates alias', async engine => {
+  const q = 'CALL { MATCH (p:Person) RETURN p.name AS name } RETURN name';
+  const out = [];
+  for await (const row of engine.run(q)) out.push(row.name);
+  assert.deepStrictEqual(out.sort(), ['Alice', 'Bob', 'Carol']);
+});
+
 runOnAdapters('single hop match without rel variable', async engine => {
   const q = 'MATCH (p:Person)-[:ACTED_IN]->(m:Movie) RETURN p, m';
   const out = [];


### PR DESCRIPTION
## Summary
- add a failing e2e test covering CALL subqueries with aliases
- fix CALL execution so alias variables from the subquery are visible to the outer query

## Testing
- `npm test`