### PR TITLE
Fix typed variable length path parsing

### DIFF
--- a/packages/core/src/parser/CypherParser.ts
+++ b/packages/core/src/parser/CypherParser.ts
@@ -176,6 +176,7 @@ export interface MatchPathQuery {
     labels?: string[];
     properties?: Record<string, unknown>;
   };
+  relType?: string;
   minHops?: number;
   maxHops?: number;
   direction?: 'out' | 'in' | 'none';
@@ -966,6 +967,10 @@ class Parser {
         this.consume('punct', '-');
       }
       this.consume('punct', '[');
+      let relType: string | undefined;
+      if (this.optional('punct', ':')) {
+        relType = this.parseIdentifier();
+      }
       this.consume('punct', '*');
       let minHops: number | undefined;
       let maxHops: number | undefined;
@@ -1009,6 +1014,7 @@ class Parser {
         pathVariable,
         start: { variable: start.variable, labels: start.labels, properties: start.properties },
         end: { variable: end.variable, labels: end.labels, properties: end.properties },
+        relType,
         minHops,
         maxHops,
         direction,

--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -83,13 +83,17 @@ async function findPath(
   endId: number | string,
   minHops = 1,
   maxHops = Infinity,
-  direction: 'out' | 'in' | 'none' = 'out'
+  direction: 'out' | 'in' | 'none' = 'out',
+  relType?: string
 ): Promise<NodeRecord[] | null> {
   if (!adapter.scanRelationships || !adapter.getNodeById) {
     throw new Error('Adapter does not support path finding');
   }
   const rels: RelRecord[] = [];
-  for await (const r of adapter.scanRelationships()) rels.push(r);
+  for await (const r of adapter.scanRelationships()) {
+    if (relType && r.type !== relType) continue;
+    rels.push(r);
+  }
   const queue: (Array<number | string>)[] = [[startId]];
   const visited = new Set<string>([`${startId}:0`]);
   while (queue.length > 0) {
@@ -1219,7 +1223,8 @@ export function logicalToPhysical(
               e.id,
               plan.minHops ?? 1,
               plan.maxHops ?? Infinity,
-              plan.direction ?? 'out'
+              plan.direction ?? 'out',
+              plan.relType
             );
             if (!path) continue;
             vars.set(plan.pathVariable, path);

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -546,6 +546,14 @@ runOnAdapters('variable length undirected path', async engine => {
   assert.deepStrictEqual(out, [2]);
 });
 
+runOnAdapters('typed variable length path', async engine => {
+  const q =
+    'MATCH p=(a:Person {name:"Alice"})-[:ACTED_IN*]->(m:Movie {title:"John Wick"}) RETURN length(p) AS len';
+  const out = [];
+  for await (const row of engine.run(q)) out.push(row.len);
+  assert.deepStrictEqual(out, [1]);
+});
+
 runOnAdapters('multi-hop ->()-> chain returns final node', async engine => {
   const out = [];
   const q =


### PR DESCRIPTION
## Summary
- add e2e test for typed variable-length paths
- support optional relationship type in variable-length paths
- filter relationships by type when resolving paths

## Testing
- `npm test`