### PR TITLE
Support named path variables for simple chains

### DIFF
--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -506,6 +506,19 @@ runOnAdapters('variable length path can return end node', async engine => {
   assert.deepStrictEqual(out, ['Action']);
 });
 
+runOnAdapters('named single-hop path returns node list', async engine => {
+  const q =
+    'MATCH p=(a:Person {name:"Alice"})-[:ACTED_IN]->(m:Movie {title:"The Matrix"}) RETURN p';
+  const out = [];
+  for await (const row of engine.run(q)) out.push(row.p);
+  assert.strictEqual(out.length, 1);
+  assert.ok(Array.isArray(out[0]));
+  assert.deepStrictEqual(
+    out[0].map(n => n.properties.name || n.properties.title),
+    ['Alice', 'The Matrix']
+  );
+});
+
 runOnAdapters('length() on path returns hop count', async engine => {
   const q =
     'MATCH p=(a:Person {name:"Alice"})-[*]->(g:Genre {name:"Action"}) RETURN length(p) AS len';


### PR DESCRIPTION
## Summary
- add `pathVariable` to `MatchChainQuery`
- parse named paths for single-hop or multi-hop chains
- track and output path arrays in physical plan when `pathVariable` is used
- test simple named path query

## Testing
- `npm test`