### PR TITLE
Add support for type() function

### DIFF
--- a/packages/core/src/parser/CypherParser.ts
+++ b/packages/core/src/parser/CypherParser.ts
@@ -89,6 +89,7 @@ export type Expression =
   | { type: 'Avg'; expression: Expression; distinct?: boolean }
   | { type: 'Collect'; expression: Expression; distinct?: boolean }
   | { type: 'Length'; variable: string }
+  | { type: 'Type'; variable: string }
   | { type: 'All' };
 
 export type WhereClause =
@@ -630,6 +631,13 @@ class Parser {
         const inner = this.parseIdentifier();
         this.consume('punct', ')');
         return { type: 'Length', variable: inner };
+      }
+      if (tok.value === 'type' && this.lookahead()?.value === '(') {
+        this.pos++;
+        this.consume('punct', '(');
+        const inner = this.parseIdentifier();
+        this.consume('punct', ')');
+        return { type: 'Type', variable: inner };
       }
       if (tok.value === 'id' && this.lookahead()?.value === '(') {
         this.pos++;

--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -66,6 +66,10 @@ function evalExpr(
       }
       return undefined;
     }
+    case 'Type': {
+      const rec = vars.get(expr.variable) as RelRecord | undefined;
+      return rec ? rec.type : undefined;
+    }
     case 'Id': {
       const rec = vars.get(expr.variable) as NodeRecord | RelRecord | undefined;
       return rec ? rec.id : undefined;

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -1057,6 +1057,13 @@ runOnAdapters('id() on relationship returns rel id', async engine => {
   assert.deepStrictEqual(out, [7]);
 });
 
+runOnAdapters('type() on relationship returns rel type', async engine => {
+  const out = [];
+  const q = 'MATCH ()-[r:ACTED_IN {role:"Neo"}]->() RETURN type(r) AS type';
+  for await (const row of engine.run(q)) out.push(row.type);
+  assert.deepStrictEqual(out, ['ACTED_IN']);
+});
+
 runOnAdapters('WITH alias named id allowed', async engine => {
   const q = 'MATCH (n:Person {name:"Alice"}) WITH id(n) AS id RETURN id';
   const out = [];


### PR DESCRIPTION
## Summary
- support `type()` expression in parser and executor
- test `type()` on relationships

## Testing
- `npm test`