### PR TITLE
Add sql.js adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ This repository currently contains a small proof-of-concept implementation. Only
 ```ts
 import { CypherEngine } from '@cypher-anywhere/core';
 import { JsonAdapter } from '@cypher-anywhere/json-adapter';
+import { SqlJsAdapter } from '@cypher-anywhere/sqljs-adapter';
 
-const adapter = new JsonAdapter({ datasetPath: './tests/data/sample.json' });
+const adapter = new SqlJsAdapter({ datasetPath: './tests/data/sample.json' });
 const engine = new CypherEngine({ adapter });
 
 for await (const row of engine.run('MATCH (n) RETURN n')) {

--- a/package.json
+++ b/package.json
@@ -7,14 +7,18 @@
   ],
   "scripts": {
     "build": "npm run build:packages",
-    "build:packages": "tsc -b packages/core packages/adapters/json-adapter",
+    "build:packages": "tsc -b packages/core packages/adapters/json-adapter packages/adapters/sqljs-adapter",
     "build:demo": "node build-demo.js",
     "test": "npm run build && node --test tests/*.js"
   },
   "devDependencies": {
-    "typescript": "^5.2.2",
+    "esbuild": "^0.20.0",
     "jest": "^29.6.1",
     "ts-jest": "^29.1.1",
-    "esbuild": "^0.20.0"
+    "typescript": "^5.2.2"
+  },
+  "dependencies": {
+    "@types/sql.js": "^1.4.9",
+    "sql.js": "^1.13.0"
   }
 }

--- a/packages/adapters/sqljs-adapter/package.json
+++ b/packages/adapters/sqljs-adapter/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@cypher-anywhere/sqljs-adapter",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "dependencies": {
+    "@cypher-anywhere/core": "0.0.1",
+    "sql.js": "^1.13.0"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "jest"
+  }
+}

--- a/packages/adapters/sqljs-adapter/src/index.ts
+++ b/packages/adapters/sqljs-adapter/src/index.ts
@@ -1,0 +1,250 @@
+import {
+  StorageAdapter,
+  NodeRecord,
+  RelRecord,
+  NodeScanSpec,
+  TransactionCtx,
+  IndexMetadata,
+} from '@cypher-anywhere/core';
+import type * as fsType from 'fs';
+import initSqlJs, { Database } from 'sql.js';
+
+// Declare Node's require for TypeScript without pulling in Node types
+declare var require: (module: string) => unknown;
+
+export interface Dataset {
+  nodes: NodeRecord[];
+  relationships: RelRecord[];
+}
+
+export interface SqlJsAdapterOptions {
+  datasetPath?: string;
+  dataset?: Dataset;
+  indexes?: IndexMetadata[];
+}
+
+export class SqlJsAdapter implements StorageAdapter {
+  private db!: Database;
+  private ready: Promise<void>;
+  private indexes: IndexMetadata[];
+
+  constructor(options: SqlJsAdapterOptions) {
+    this.indexes = options.indexes ?? [];
+    this.ready = this.init(options);
+  }
+
+  private async init(options: SqlJsAdapterOptions): Promise<void> {
+    const SQL = await initSqlJs();
+    this.db = new SQL.Database();
+    this.db.run(
+      'CREATE TABLE nodes (id INTEGER PRIMARY KEY, labels TEXT, properties TEXT)'
+    );
+    this.db.run(
+      'CREATE TABLE edges (id INTEGER PRIMARY KEY, type TEXT, startNode INTEGER, endNode INTEGER, properties TEXT)'
+    );
+    let data: Dataset | undefined = options.dataset;
+    if (!data && options.datasetPath) {
+      const fs = require('fs') as typeof fsType;
+      const text = fs.readFileSync(options.datasetPath, 'utf8');
+      data = JSON.parse(text);
+    }
+    if (!data) throw new Error('dataset or datasetPath must be provided');
+    const insertNode = this.db.prepare(
+      'INSERT INTO nodes VALUES (?, ?, ?)'
+    );
+    for (const n of data.nodes) {
+      insertNode.run([n.id, JSON.stringify(n.labels), JSON.stringify(n.properties)]);
+    }
+    insertNode.free();
+    const insertRel = this.db.prepare(
+      'INSERT INTO edges VALUES (?, ?, ?, ?, ?)'
+    );
+    for (const r of data.relationships) {
+      insertRel.run([
+        r.id,
+        r.type,
+        r.startNode,
+        r.endNode,
+        JSON.stringify(r.properties),
+      ]);
+    }
+    insertRel.free();
+  }
+
+  private async ensureReady(): Promise<void> {
+    await this.ready;
+  }
+
+  private rowToNode(row: any): NodeRecord {
+    return {
+      id: row.id,
+      labels: JSON.parse(row.labels),
+      properties: JSON.parse(row.properties || '{}'),
+    };
+  }
+
+  private rowToRel(row: any): RelRecord {
+    return {
+      id: row.id,
+      type: row.type,
+      startNode: row.startNode,
+      endNode: row.endNode,
+      properties: JSON.parse(row.properties || '{}'),
+    };
+  }
+
+  async getNodeById(id: number | string): Promise<NodeRecord | null> {
+    await this.ensureReady();
+    const stmt = this.db.prepare(
+      'SELECT id, labels, properties FROM nodes WHERE id = ?'
+    );
+    stmt.bind([id]);
+    const row = stmt.step() ? stmt.getAsObject() : null;
+    stmt.free();
+    return row ? this.rowToNode(row) : null;
+  }
+
+  async *scanNodes(spec: NodeScanSpec = {}): AsyncIterable<NodeRecord> {
+    await this.ensureReady();
+    const stmt = this.db.prepare(
+      'SELECT id, labels, properties FROM nodes'
+    );
+    while (stmt.step()) {
+      const row = this.rowToNode(stmt.getAsObject());
+      const { label, labels } = spec;
+      const labelMatch = label ? row.labels.includes(label) : true;
+      const labelsMatch = labels ? labels.every(l => row.labels.includes(l)) : true;
+      if (labelMatch && labelsMatch) {
+        yield row;
+      }
+    }
+    stmt.free();
+  }
+
+  async createNode(labels: string[], properties: Record<string, unknown>): Promise<NodeRecord> {
+    await this.ensureReady();
+    const stmt = this.db.prepare('SELECT MAX(id) as id FROM nodes');
+    const row = stmt.step() ? stmt.getAsObject() : { id: 0 };
+    stmt.free();
+    const id = Number(row.id) + 1;
+    const node: NodeRecord = { id, labels, properties };
+    this.db.run('INSERT INTO nodes VALUES (?, ?, ?)', [id, JSON.stringify(labels), JSON.stringify(properties)]);
+    return node;
+  }
+
+  async deleteNode(id: number | string): Promise<void> {
+    await this.ensureReady();
+    this.db.run('DELETE FROM edges WHERE startNode = ? OR endNode = ?', [id, id]);
+    this.db.run('DELETE FROM nodes WHERE id = ?', [id]);
+  }
+
+  async updateNodeProperties(id: number | string, properties: Record<string, unknown>): Promise<void> {
+    await this.ensureReady();
+    const node = await this.getNodeById(id);
+    if (!node) throw new Error('node not found');
+    Object.assign(node.properties, properties);
+    this.db.run('UPDATE nodes SET properties = ? WHERE id = ?', [JSON.stringify(node.properties), id]);
+  }
+
+  async findNode(labels: string[], properties: Record<string, unknown>): Promise<NodeRecord | null> {
+    await this.ensureReady();
+    const stmt = this.db.prepare('SELECT id, labels, properties FROM nodes');
+    while (stmt.step()) {
+      const row = this.rowToNode(stmt.getAsObject());
+      if (labels.length && !labels.every(l => row.labels.includes(l))) continue;
+      let ok = true;
+      for (const [k, v] of Object.entries(properties)) {
+        if (row.properties[k] !== v) {
+          ok = false;
+          break;
+        }
+      }
+      if (ok) {
+        stmt.free();
+        return row;
+      }
+    }
+    stmt.free();
+    return null;
+  }
+
+  async *indexLookup(label: string | undefined, property: string, value: unknown): AsyncIterable<NodeRecord> {
+    await this.ensureReady();
+    const stmt = this.db.prepare('SELECT id, labels, properties FROM nodes');
+    while (stmt.step()) {
+      const row = this.rowToNode(stmt.getAsObject());
+      if (label && !row.labels.includes(label)) continue;
+      if (row.properties[property] === value) {
+        yield row;
+      }
+    }
+    stmt.free();
+  }
+
+  async listIndexes(): Promise<IndexMetadata[]> {
+    await this.ensureReady();
+    return this.indexes;
+  }
+
+  async getRelationshipById(id: number | string): Promise<RelRecord | null> {
+    await this.ensureReady();
+    const stmt = this.db.prepare(
+      'SELECT id, type, startNode, endNode, properties FROM edges WHERE id = ?'
+    );
+    stmt.bind([id]);
+    const row = stmt.step() ? stmt.getAsObject() : null;
+    stmt.free();
+    return row ? this.rowToRel(row) : null;
+  }
+
+  async *scanRelationships(): AsyncIterable<RelRecord> {
+    await this.ensureReady();
+    const stmt = this.db.prepare(
+      'SELECT id, type, startNode, endNode, properties FROM edges'
+    );
+    while (stmt.step()) {
+      yield this.rowToRel(stmt.getAsObject());
+    }
+    stmt.free();
+  }
+
+  async createRelationship(type: string, startNode: number | string, endNode: number | string, properties: Record<string, unknown>): Promise<RelRecord> {
+    await this.ensureReady();
+    const stmt = this.db.prepare('SELECT MAX(id) as id FROM edges');
+    const row = stmt.step() ? stmt.getAsObject() : { id: 0 };
+    stmt.free();
+    const id = Number(row.id) + 1;
+    const rel: RelRecord = { id, type, startNode, endNode, properties };
+    this.db.run('INSERT INTO edges VALUES (?, ?, ?, ?, ?)', [id, type, startNode, endNode, JSON.stringify(properties)]);
+    return rel;
+  }
+
+  async deleteRelationship(id: number | string): Promise<void> {
+    await this.ensureReady();
+    this.db.run('DELETE FROM edges WHERE id = ?', [id]);
+  }
+
+  async updateRelationshipProperties(id: number | string, properties: Record<string, unknown>): Promise<void> {
+    await this.ensureReady();
+    const rel = await this.getRelationshipById(id);
+    if (!rel) throw new Error('relationship not found');
+    Object.assign(rel.properties, properties);
+    this.db.run('UPDATE edges SET properties = ? WHERE id = ?', [JSON.stringify(rel.properties), id]);
+  }
+
+  async beginTransaction(): Promise<TransactionCtx> {
+    await this.ensureReady();
+    this.db.run('BEGIN TRANSACTION');
+    return {};
+  }
+
+  async commit(_: TransactionCtx): Promise<void> {
+    await this.ensureReady();
+    this.db.run('COMMIT');
+  }
+
+  async rollback(_: TransactionCtx): Promise<void> {
+    await this.ensureReady();
+    this.db.run('ROLLBACK');
+  }
+}

--- a/packages/adapters/sqljs-adapter/tsconfig.json
+++ b/packages/adapters/sqljs-adapter/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": true
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../../core" }
+  ]
+}

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -1,6 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert');
 const { JsonAdapter } = require('../packages/adapters/json-adapter/dist');
+const { SqlJsAdapter } = require('../packages/adapters/sqljs-adapter/dist');
 const { CypherEngine } = require('../packages/core/dist');
 
 const baseData = {
@@ -22,6 +23,13 @@ const baseData = {
 
 const adapterFactories = {
   json: () => new JsonAdapter({
+    dataset: JSON.parse(JSON.stringify(baseData)),
+    indexes: [
+      { label: 'Person', properties: ['name'], unique: true },
+      { label: 'Movie', properties: ['title'], unique: true }
+    ]
+  }),
+  sqljs: () => new SqlJsAdapter({
     dataset: JSON.parse(JSON.stringify(baseData)),
     indexes: [
       { label: 'Person', properties: ['name'], unique: true },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -12,7 +12,9 @@
       "@cypher-anywhere/core": ["packages/core/src"],
       "@cypher-anywhere/core/*": ["packages/core/src/*"],
       "@cypher-anywhere/json-adapter": ["packages/adapters/json-adapter/src"],
-      "@cypher-anywhere/json-adapter/*": ["packages/adapters/json-adapter/src/*"]
+      "@cypher-anywhere/json-adapter/*": ["packages/adapters/json-adapter/src/*"],
+      "@cypher-anywhere/sqljs-adapter": ["packages/adapters/sqljs-adapter/src"],
+      "@cypher-anywhere/sqljs-adapter/*": ["packages/adapters/sqljs-adapter/src/*"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- add sqljs adapter using in-memory sql.js database
- add sqljs adapter build config and workspace paths
- update README example
- run sqljs adapter in e2e tests

## Testing
- `npm test`