### PR TITLE
Add schema-aware sql.js adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "scripts": {
     "build": "npm run build:packages",
-    "build:packages": "tsc -b packages/core packages/adapters/json-adapter packages/adapters/sqljs-adapter",
+    "build:packages": "tsc -b packages/core packages/adapters/json-adapter packages/adapters/sqljs-adapter packages/adapters/sqljs-schema-adapter",
     "build:demo": "node build-demo.js",
     "test": "npm run build && node --test tests/*.js"
   },

--- a/packages/adapters/sqljs-schema-adapter/package.json
+++ b/packages/adapters/sqljs-schema-adapter/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@cypher-anywhere/sqljs-schema-adapter",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "dependencies": {
+    "@cypher-anywhere/core": "0.0.1",
+    "sql.js": "^1.13.0"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "jest"
+  }
+}

--- a/packages/adapters/sqljs-schema-adapter/src/index.ts
+++ b/packages/adapters/sqljs-schema-adapter/src/index.ts
@@ -1,0 +1,157 @@
+import {
+  StorageAdapter,
+  NodeRecord,
+  RelRecord,
+  NodeScanSpec,
+  IndexMetadata
+} from '@cypher-anywhere/core';
+import initSqlJs, { Database } from 'sql.js';
+
+export interface NodeTableSpec {
+  table: string;
+  id: string;
+  labels?: string[];
+  labelColumn?: string;
+  properties: string[];
+}
+
+export interface RelationshipTableSpec {
+  table: string;
+  id: string;
+  start: string;
+  end: string;
+  type?: string;
+  typeColumn?: string;
+  properties: string[];
+}
+
+export interface SchemaSpec {
+  nodes: NodeTableSpec[];
+  relationships: RelationshipTableSpec[];
+}
+
+export interface SqlJsSchemaAdapterOptions {
+  schema: SchemaSpec;
+  setup?: (db: Database) => void | Promise<void>;
+  indexes?: IndexMetadata[];
+}
+
+export class SqlJsSchemaAdapter implements StorageAdapter {
+  private db!: Database;
+  private ready: Promise<void>;
+  private schema: SchemaSpec;
+  private indexes: IndexMetadata[];
+
+  constructor(options: SqlJsSchemaAdapterOptions) {
+    this.schema = options.schema;
+    this.indexes = options.indexes ?? [];
+    this.ready = this.init(options);
+  }
+
+  private async init(options: SqlJsSchemaAdapterOptions): Promise<void> {
+    const SQL = await initSqlJs();
+    this.db = new SQL.Database();
+    if (options.setup) await options.setup(this.db);
+  }
+
+  private async ensureReady(): Promise<void> {
+    await this.ready;
+  }
+
+  private rowToNode(row: any, spec: NodeTableSpec): NodeRecord {
+    const labels: string[] = [];
+    if (spec.labels) labels.push(...spec.labels);
+    if (spec.labelColumn && row[spec.labelColumn]) {
+      const val = row[spec.labelColumn];
+      if (typeof val === 'string') {
+        try {
+          const arr = JSON.parse(val);
+          if (Array.isArray(arr)) labels.push(...arr);
+          else labels.push(String(arr));
+        } catch {
+          if (val.includes(',')) labels.push(...val.split(',').map(s => s.trim()));
+          else labels.push(val);
+        }
+      } else if (Array.isArray(val)) {
+        labels.push(...val);
+      }
+    }
+    const properties: Record<string, unknown> = {};
+    for (const col of spec.properties) {
+      properties[col] = row[col];
+    }
+    return { id: row[spec.id], labels, properties };
+  }
+
+  private rowToRel(row: any, spec: RelationshipTableSpec): RelRecord {
+    const properties: Record<string, unknown> = {};
+    for (const col of spec.properties) {
+      properties[col] = row[col];
+    }
+    const type = spec.type ?? (spec.typeColumn ? row[spec.typeColumn] : undefined);
+    return {
+      id: row[spec.id],
+      type: type as string,
+      startNode: row[spec.start],
+      endNode: row[spec.end],
+      properties
+    };
+  }
+
+  async getNodeById(id: number | string): Promise<NodeRecord | null> {
+    await this.ensureReady();
+    for (const spec of this.schema.nodes) {
+      const stmt = this.db.prepare(`SELECT * FROM ${spec.table} WHERE ${spec.id} = ?`);
+      stmt.bind([id]);
+      const row = stmt.step() ? stmt.getAsObject() : null;
+      stmt.free();
+      if (row) return this.rowToNode(row, spec);
+    }
+    return null;
+  }
+
+  async *scanNodes(spec: NodeScanSpec = {}): AsyncIterable<NodeRecord> {
+    await this.ensureReady();
+    for (const table of this.schema.nodes) {
+      const stmt = this.db.prepare(`SELECT * FROM ${table.table}`);
+      while (stmt.step()) {
+        const row = this.rowToNode(stmt.getAsObject(), table);
+        const { label, labels } = spec;
+        const labelMatch = label ? row.labels.includes(label) : true;
+        const labelsMatch = labels ? labels.every(l => row.labels.includes(l)) : true;
+        if (labelMatch && labelsMatch) {
+          yield row;
+        }
+      }
+      stmt.free();
+    }
+  }
+
+  async getRelationshipById(id: number | string): Promise<RelRecord | null> {
+    await this.ensureReady();
+    for (const spec of this.schema.relationships) {
+      const stmt = this.db.prepare(`SELECT * FROM ${spec.table} WHERE ${spec.id} = ?`);
+      stmt.bind([id]);
+      const row = stmt.step() ? stmt.getAsObject() : null;
+      stmt.free();
+      if (row) return this.rowToRel(row, spec);
+    }
+    return null;
+  }
+
+  async *scanRelationships(): AsyncIterable<RelRecord> {
+    await this.ensureReady();
+    for (const table of this.schema.relationships) {
+      const stmt = this.db.prepare(`SELECT * FROM ${table.table}`);
+      while (stmt.step()) {
+        yield this.rowToRel(stmt.getAsObject(), table);
+      }
+      stmt.free();
+    }
+  }
+
+  async listIndexes(): Promise<IndexMetadata[]> {
+    await this.ensureReady();
+    return this.indexes;
+  }
+}

--- a/packages/adapters/sqljs-schema-adapter/tsconfig.json
+++ b/packages/adapters/sqljs-schema-adapter/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": true
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../../core" }
+  ]
+}

--- a/tests/sqljs-schema-adapter.test.js
+++ b/tests/sqljs-schema-adapter.test.js
@@ -1,0 +1,95 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { SqlJsSchemaAdapter } = require('../packages/adapters/sqljs-schema-adapter/dist');
+
+function makeAdapter(options) {
+  return new SqlJsSchemaAdapter(options);
+}
+
+test('schema with table-defined labels', async () => {
+  const schema = {
+    nodes: [
+      { table: 'people', id: 'id', labels: ['Person'], properties: ['name'] }
+    ],
+    relationships: [
+      { table: 'knows', id: 'id', start: 'src', end: 'dst', type: 'KNOWS', properties: [] }
+    ]
+  };
+  const adapter = makeAdapter({
+    schema,
+    setup(db) {
+      db.run('CREATE TABLE people (id INTEGER, name TEXT);');
+      db.run('CREATE TABLE knows (id INTEGER, src INTEGER, dst INTEGER);');
+      db.run('INSERT INTO people VALUES (1, "Alice"), (2, "Bob");');
+      db.run('INSERT INTO knows VALUES (3,1,2);');
+    }
+  });
+  const nodes = [];
+  for await (const n of adapter.scanNodes()) nodes.push(n);
+  assert.strictEqual(nodes.length, 2);
+  assert.deepStrictEqual(nodes[0].labels, ['Person']);
+  const rels = [];
+  for await (const r of adapter.scanRelationships()) rels.push(r);
+  assert.strictEqual(rels.length, 1);
+  assert.strictEqual(rels[0].type, 'KNOWS');
+});
+
+test('labels and types from columns', async () => {
+  const schema = {
+    nodes: [
+      { table: 'nodes', id: 'id', labelColumn: 'label', properties: ['name'] }
+    ],
+    relationships: [
+      { table: 'edges', id: 'id', start: 'start', end: 'end', typeColumn: 'type', properties: [] }
+    ]
+  };
+  const adapter = makeAdapter({
+    schema,
+    setup(db) {
+      db.run('CREATE TABLE nodes (id INTEGER, label TEXT, name TEXT);');
+      db.run('CREATE TABLE edges (id INTEGER, type TEXT, start INTEGER, end INTEGER);');
+      db.run('INSERT INTO nodes VALUES (1, "Person", "Alice"), (2, "Movie", "Matrix");');
+      db.run('INSERT INTO edges VALUES (3, "ACTED_IN", 1, 2);');
+    }
+  });
+  const people = [];
+  for await (const n of adapter.scanNodes({ label: 'Person' })) people.push(n);
+  assert.strictEqual(people.length, 1);
+  assert.strictEqual(people[0].properties.name, 'Alice');
+  const rel = await adapter.getRelationshipById(3);
+  assert.ok(rel);
+  assert.strictEqual(rel.type, 'ACTED_IN');
+});
+
+test('multiple node tables and implicit edge type', async () => {
+  const schema = {
+    nodes: [
+      { table: 'people', id: 'pid', labels: ['Person'], properties: ['name'] },
+      { table: 'movies', id: 'mid', labels: ['Movie'], properties: ['title'] }
+    ],
+    relationships: [
+      { table: 'acted', id: 'id', start: 'person', end: 'movie', type: 'ACTED_IN', properties: [] }
+    ]
+  };
+  const adapter = makeAdapter({
+    schema,
+    setup(db) {
+      db.run('CREATE TABLE people (pid INTEGER, name TEXT);');
+      db.run('CREATE TABLE movies (mid INTEGER, title TEXT);');
+      db.run('CREATE TABLE acted (id INTEGER, person INTEGER, movie INTEGER);');
+      db.run('INSERT INTO people VALUES (1, "Alice");');
+      db.run('INSERT INTO movies VALUES (2, "Matrix");');
+      db.run('INSERT INTO acted VALUES (3, 1, 2);');
+    }
+  });
+  const persons = [];
+  for await (const n of adapter.scanNodes({ label: 'Person' })) persons.push(n);
+  assert.strictEqual(persons.length, 1);
+  const movies = [];
+  for await (const n of adapter.scanNodes({ label: 'Movie' })) movies.push(n);
+  assert.strictEqual(movies.length, 1);
+  const rels = [];
+  for await (const r of adapter.scanRelationships()) rels.push(r);
+  assert.strictEqual(rels.length, 1);
+  assert.strictEqual(rels[0].startNode, 1);
+});

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,6 +15,8 @@
       "@cypher-anywhere/json-adapter/*": ["packages/adapters/json-adapter/src/*"],
       "@cypher-anywhere/sqljs-adapter": ["packages/adapters/sqljs-adapter/src"],
       "@cypher-anywhere/sqljs-adapter/*": ["packages/adapters/sqljs-adapter/src/*"]
+      ,"@cypher-anywhere/sqljs-schema-adapter": ["packages/adapters/sqljs-schema-adapter/src"],
+      "@cypher-anywhere/sqljs-schema-adapter/*": ["packages/adapters/sqljs-schema-adapter/src/*"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- implement new SqlJsSchemaAdapter for sql.js with explicit schema mapping
- wire workspace and build scripts for the new package
- provide unit tests exercising different schema configurations

## Testing
- `npm test`