### PR TITLE
Add ORDER BY and limit support after CALL

### DIFF
--- a/packages/core/src/parser/CypherParser.ts
+++ b/packages/core/src/parser/CypherParser.ts
@@ -215,6 +215,9 @@ export interface CallQuery {
   subquery: CypherAST[];
   returnItems: ReturnItem[];
   distinct?: boolean;
+  orderBy?: { expression: Expression; direction?: 'ASC' | 'DESC' }[];
+  skip?: Expression;
+  limit?: Expression;
 }
 
 export interface MatchChainQuery {
@@ -1493,7 +1496,15 @@ class Parser {
     const innerQuery = innerTokens.map(t => t.value).join(' ');
     const subquery = parseMany(innerQuery);
     const ret = this.parseReturnClause();
-    return { type: 'Call', subquery, returnItems: ret.items, distinct: ret.distinct };
+    return {
+      type: 'Call',
+      subquery,
+      returnItems: ret.items,
+      distinct: ret.distinct,
+      orderBy: ret.orderBy,
+      skip: ret.skip,
+      limit: ret.limit,
+    };
   }
 }
 

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -965,6 +965,21 @@ runOnAdapters('CALL subquery propagates alias', async engine => {
   assert.deepStrictEqual(out.sort(), ['Alice', 'Bob', 'Carol']);
 });
 
+runOnAdapters('CALL with ORDER BY applies ordering', async engine => {
+  const q = 'CALL { RETURN 2 AS x UNION ALL RETURN 1 AS x } RETURN x ORDER BY x';
+  const out = [];
+  for await (const row of engine.run(q)) out.push(row.x);
+  assert.deepStrictEqual(out, [1, 2]);
+});
+
+runOnAdapters('CALL with ORDER BY SKIP LIMIT', async engine => {
+  const q =
+    'CALL { UNWIND [1,2,3] AS x RETURN x } RETURN x ORDER BY x DESC SKIP 1 LIMIT 1';
+  const out = [];
+  for await (const row of engine.run(q)) out.push(row.x);
+  assert.deepStrictEqual(out, [2]);
+});
+
 runOnAdapters('single hop match without rel variable', async engine => {
   const q = 'MATCH (p:Person)-[:ACTED_IN]->(m:Movie) RETURN p, m';
   const out = [];


### PR DESCRIPTION
## Summary
- allow `CALL` queries to honor ORDER BY, SKIP and LIMIT
- extend `CallQuery` AST representation
- update parser and physical plan to process the new fields
- add e2e tests covering ordered and limited results from CALL subqueries

## Testing
- `npm test`