### PR TITLE
Fix MATCH without variable

### DIFF
--- a/packages/core/src/parser/CypherParser.ts
+++ b/packages/core/src/parser/CypherParser.ts
@@ -1178,8 +1178,15 @@ class Parser {
       this.parseMaybeNodePattern();
       pattern = { variable: relVar, labels: relType ? [relType] : undefined, properties: relProps, isRel: true };
     } else {
-      if (!start.variable) throw new Error('Parse error: node variable required');
-      pattern = { variable: start.variable, labels: start.labels, properties: start.properties, isRel: false };
+      if (!start.variable) {
+        start.variable = this.genAnonVar();
+      }
+      pattern = {
+        variable: start.variable,
+        labels: start.labels,
+        properties: start.properties,
+        isRel: false,
+      };
     }
     let where: WhereClause | undefined;
     if (this.current()?.value === 'WHERE') {

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -1171,3 +1171,10 @@ runOnAdapters('alias used in subsequent pattern property', async engine => {
   assert.strictEqual(out.length, 1);
   assert.strictEqual(out[0].properties.name, 'Alice');
 });
+
+runOnAdapters('MATCH without variable returns count', async engine => {
+  const q = 'MATCH (:Person) RETURN COUNT(*) AS cnt';
+  const out = [];
+  for await (const row of engine.run(q)) out.push(row.cnt);
+  assert.deepStrictEqual(out, [3]);
+});


### PR DESCRIPTION
## Summary
- allow MATCH patterns without explicit variable
- cover MATCH without variable in e2e tests

## Testing
- `npm run build`
- `npm test`