### PR TITLE
Fix index state after JSON adapter rollback

### DIFF
--- a/packages/adapters/json-adapter/src/index.ts
+++ b/packages/adapters/json-adapter/src/index.ts
@@ -268,10 +268,15 @@ export class JsonAdapter implements StorageAdapter {
       this.data.nodes = this.txData.nodes;
       this.data.relationships = this.txData.relationships;
       this.txData = undefined;
+      this.buildIndexes();
     }
   }
 
   async rollback(_: TransactionCtx): Promise<void> {
-    this.txData = undefined;
+    if (this.txData) {
+      this.txData = undefined;
+      // Rebuild indexes from the untouched base data
+      this.buildIndexes();
+    }
   }
 }

--- a/tests/json-adapter.test.js
+++ b/tests/json-adapter.test.js
@@ -67,6 +67,19 @@ test('JsonAdapter transaction rollback discards changes', async () => {
   assert.strictEqual(res.length, 0);
 });
 
+test('JsonAdapter rollback restores indexes', async () => {
+  const adapter = new JsonAdapter({
+    dataset: { nodes: [], relationships: [] },
+    indexes: [{ label: 'Person', properties: ['name'], unique: true }]
+  });
+  const tx = await adapter.beginTransaction();
+  await adapter.createNode(['Person'], { name: 'Tmp' });
+  await adapter.rollback(tx);
+  const results = [];
+  for await (const n of adapter.indexLookup('Person', 'name', 'Tmp')) results.push(n);
+  assert.strictEqual(results.length, 0);
+});
+
 test('JsonAdapter node property updates and deletion', async () => {
   const adapter = new JsonAdapter({ datasetPath });
   const node = await adapter.createNode(['Test'], { x: 1 });


### PR DESCRIPTION
## Summary
- rebuild JSON adapter indexes on transaction rollback or commit
- add regression test ensuring indexes are restored after rollback

## Testing
- `npm test`