### PR TITLE
Support quoted identifiers

### DIFF
--- a/packages/core/src/parser/CypherParser.ts
+++ b/packages/core/src/parser/CypherParser.ts
@@ -296,6 +296,15 @@ function tokenize(input: string): Token[] {
       i += keyword[0].length;
       continue;
     }
+    const quoted = /^`([^`]|``)*`/.exec(rest);
+    if (quoted) {
+      tokens.push({
+        type: 'identifier',
+        value: quoted[0].slice(1, -1).replace(/``/g, '`'),
+      });
+      i += quoted[0].length;
+      continue;
+    }
     const ident = /^[_A-Za-z][_A-Za-z0-9]*/.exec(rest);
     if (ident) {
       tokens.push({ type: 'identifier', value: ident[0] });

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -1187,6 +1187,19 @@ runOnAdapters('alias used in subsequent pattern property', async engine => {
   assert.strictEqual(out[0].properties.name, 'Alice');
 });
 
+runOnAdapters('quoted identifiers for label, variable and property', async engine => {
+  let node;
+  for await (const row of engine.run('CREATE (`x-y`:`weird-label` {`first-name`:"Zoe"}) RETURN `x-y`'))
+    node = row['x-y'];
+  assert.ok(node);
+  assert.deepStrictEqual(node.labels, ['weird-label']);
+  assert.strictEqual(node.properties['first-name'], 'Zoe');
+  const out = [];
+  for await (const row of engine.run('MATCH (`x-y`:`weird-label` {`first-name`:"Zoe"}) RETURN `x-y`.`first-name` AS fn'))
+    out.push(row.fn);
+  assert.deepStrictEqual(out, ['Zoe']);
+});
+
 runOnAdapters('MATCH without variable returns count', async engine => {
   const q = 'MATCH (:Person) RETURN COUNT(*) AS cnt';
   const out = [];


### PR DESCRIPTION
## Summary
- allow backtick-quoted identifiers in parser
- add an E2E test showing labels, variables and properties can be quoted

## Testing
- `npm run build`
- `npm test`