### PR TITLE
Add labels() function

### DIFF
--- a/packages/core/src/parser/CypherParser.ts
+++ b/packages/core/src/parser/CypherParser.ts
@@ -89,6 +89,7 @@ export type Expression =
   | { type: 'Avg'; expression: Expression; distinct?: boolean }
   | { type: 'Collect'; expression: Expression; distinct?: boolean }
   | { type: 'Length'; variable: string }
+  | { type: 'Labels'; variable: string }
   | { type: 'Type'; variable: string }
   | { type: 'All' };
 
@@ -635,6 +636,13 @@ class Parser {
         const inner = this.parseIdentifier();
         this.consume('punct', ')');
         return { type: 'Length', variable: inner };
+      }
+      if (tok.value === 'labels' && this.lookahead()?.value === '(') {
+        this.pos++;
+        this.consume('punct', '(');
+        const inner = this.parseIdentifier();
+        this.consume('punct', ')');
+        return { type: 'Labels', variable: inner };
       }
       if (tok.value === 'type' && this.lookahead()?.value === '(') {
         this.pos++;

--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -66,6 +66,10 @@ function evalExpr(
       }
       return undefined;
     }
+    case 'Labels': {
+      const rec = vars.get(expr.variable) as NodeRecord | undefined;
+      return rec ? rec.labels : undefined;
+    }
     case 'Type': {
       const rec = vars.get(expr.variable) as RelRecord | undefined;
       return rec ? rec.type : undefined;

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -1111,6 +1111,13 @@ runOnAdapters('type() on relationship returns rel type', async engine => {
   assert.deepStrictEqual(out, ['ACTED_IN']);
 });
 
+runOnAdapters('labels() function returns node labels', async engine => {
+  const q = 'MATCH (n:Person {name:"Carol"}) RETURN labels(n) AS labs';
+  const out = [];
+  for await (const row of engine.run(q)) out.push(row.labs);
+  assert.deepStrictEqual(out, [['Person', 'Actor']]);
+});
+
 runOnAdapters('WITH alias named id allowed', async engine => {
   const q = 'MATCH (n:Person {name:"Alice"}) WITH id(n) AS id RETURN id';
   const out = [];


### PR DESCRIPTION
## Summary
- support `labels()` expression in parser and physical plan
- add e2e test verifying `labels()` returns node labels

## Testing
- `npm test`