### PR TITLE
Fix MIN/MAX aggregation null handling

### DIFF
--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -449,9 +449,9 @@ function finalizeAgg(
     case 'Sum':
       return state ? (state as any).sum ?? 0 : 0;
     case 'Min':
-      return state ? (state as any).min : undefined;
+      return state ? (state as any).min ?? null : null;
     case 'Max':
-      return state ? (state as any).max : undefined;
+      return state ? (state as any).max ?? null : null;
     case 'Avg':
       return state ? ((state as any).count ? (state as any).sum / (state as any).count : null) : null;
     case 'Collect':

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -924,6 +924,27 @@ runOnAdapters('COLLECT aggregation returns list', async engine => {
   assert.deepStrictEqual(row.names.sort(), ['Alice', 'Bob', 'Carol']);
 });
 
+runOnAdapters('MIN aggregation', async engine => {
+  const out = [];
+  const q = 'MATCH (m:Movie) RETURN MIN(m.released) AS year';
+  for await (const row of engine.run(q)) out.push(row.year);
+  assert.deepStrictEqual(out, [1999]);
+});
+
+runOnAdapters('MAX aggregation', async engine => {
+  const out = [];
+  const q = 'MATCH (m:Movie) RETURN MAX(m.released) AS year';
+  for await (const row of engine.run(q)) out.push(row.year);
+  assert.deepStrictEqual(out, [2014]);
+});
+
+runOnAdapters('MIN on empty result returns null', async engine => {
+  const out = [];
+  const q = 'MATCH (n:Missing) RETURN MIN(n.x) AS val';
+  for await (const row of engine.run(q)) out.push(row.val);
+  assert.deepStrictEqual(out, [null]);
+});
+
 runOnAdapters('UNION combines results', async engine => {
   const q =
     'MATCH (p:Person {name:"Alice"}) RETURN p.name AS name ' +


### PR DESCRIPTION
## Summary
- ensure MIN and MAX aggregations return `null` when there are no rows
- add end-to-end tests for MIN/MAX
- verify MIN returns `null` on empty results

## Testing
- `npm test`