### PR TITLE
Fix path search to allow zero hop

### DIFF
--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -128,7 +128,7 @@ async function* findPaths(
     const { nodes: path, relationships: pathRels } = queue.shift()!;
     const last = path[path.length - 1];
     const hops = path.length - 1;
-    if (last === endId && hops >= minHops && hops <= maxHops && hops > 0) {
+    if (last === endId && hops >= minHops && hops <= maxHops) {
       const nodes: NodeRecord[] = [];
       for (const id of path) {
         const n = await adapter.getNodeById(id);

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -551,6 +551,14 @@ runOnAdapters('variable length path exact length', async engine => {
   assert.deepStrictEqual(out.sort(), [1, 1]);
 });
 
+runOnAdapters('variable length path with zero minimum includes zero hop', async engine => {
+  const q =
+    'MATCH p=(a:Person {name:"Alice"})-[*0..2]->(a:Person {name:"Alice"}) RETURN length(p) AS len';
+  const out = [];
+  for await (const row of engine.run(q)) out.push(row.len);
+  assert.deepStrictEqual(out, [0]);
+});
+
 runOnAdapters('variable length incoming path', async engine => {
   const q =
     'MATCH q=(m:Movie {title:"John Wick"})<-[*]-(a:Person {name:"Alice"}) RETURN length(q) AS len';


### PR DESCRIPTION
## Summary
- add regression test for variable length paths with zero minimum
- allow zero hop paths in the path finder

## Testing
- `npm test`