### PR TITLE
Enable length() on general expressions

### DIFF
--- a/packages/core/src/parser/CypherParser.ts
+++ b/packages/core/src/parser/CypherParser.ts
@@ -88,7 +88,7 @@ export type Expression =
   | { type: 'Max'; expression: Expression; distinct?: boolean }
   | { type: 'Avg'; expression: Expression; distinct?: boolean }
   | { type: 'Collect'; expression: Expression; distinct?: boolean }
-  | { type: 'Length'; variable: string }
+  | { type: 'Length'; expression: Expression }
   | { type: 'Labels'; variable: string }
   | { type: 'Type'; variable: string }
   | { type: 'Relationships'; variable: string }
@@ -650,9 +650,9 @@ class Parser {
       if (tok.value === 'length' && this.lookahead()?.value === '(') {
         this.pos++;
         this.consume('punct', '(');
-        const inner = this.parseIdentifier();
+        const inner = this.parseValue();
         this.consume('punct', ')');
-        return { type: 'Length', variable: inner };
+        return { type: 'Length', expression: inner };
       }
       if (tok.value === 'labels' && this.lookahead()?.value === '(') {
         this.pos++;

--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -73,15 +73,17 @@ function evalExpr(
         return undefined;
       }
     case 'Length': {
-      const val = vars.get(expr.variable);
+      let val: any;
+      if (expr.expression.type === 'Variable') {
+        val = vars.get(expr.expression.name);
+      } else {
+        val = evalExpr(expr.expression, vars, params);
+      }
       if (val && typeof val === 'object' && 'relationships' in val) {
         return (val as any).relationships.length;
       }
-      if (Array.isArray(val)) {
-        return val.length > 0 ? val.length - 1 : 0;
-      }
-      if (typeof val === 'string') {
-        return val.length;
+      if (Array.isArray(val) || typeof val === 'string') {
+        return (val as any).length;
       }
       return undefined;
     }

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -1224,3 +1224,17 @@ runOnAdapters('MATCH without variable returns count', async engine => {
   for await (const row of engine.run(q)) out.push(row.cnt);
   assert.deepStrictEqual(out, [3]);
 });
+
+runOnAdapters('length() on list expression returns length', async engine => {
+  const q = 'RETURN length([1,2,3]) AS len';
+  const out = [];
+  for await (const row of engine.run(q)) out.push(row.len);
+  assert.deepStrictEqual(out, [3]);
+});
+
+runOnAdapters('length() on string expression returns length', async engine => {
+  const q = "RETURN length('abc') AS len";
+  const out = [];
+  for await (const row of engine.run(q)) out.push(row.len);
+  assert.deepStrictEqual(out, [3]);
+});


### PR DESCRIPTION
## Summary
- support length() on any expression rather than only variables
- handle path variables correctly when computing length
- add e2e tests for list and string length

## Testing
- `npm test`