### PR TITLE
Add index optimization for WHERE IN

### DIFF
--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -647,6 +647,43 @@ export function logicalToPhysical(
               usedIndex = true;
             }
           }
+          if (
+            !usedIndex &&
+            !boundNode &&
+            plan.labels &&
+            plan.labels.length > 0 &&
+            !plan.properties &&
+            adapter.indexLookup &&
+            adapter.listIndexes &&
+            plan.where &&
+            plan.where.type === 'Condition' &&
+            plan.where.operator === 'IN' &&
+            plan.where.left.type === 'Property' &&
+            plan.where.left.variable === plan.variable &&
+            plan.where.right
+          ) {
+            const prop = plan.where.left.property;
+            const values = evalExpr(plan.where.right, vars, params);
+            if (Array.isArray(values)) {
+              const indexes = await adapter.listIndexes();
+              const label = plan.labels[0];
+              const found = indexes.find(
+                i => i.label === label && i.properties.length === 1 && i.properties[0] === prop
+              );
+              if (found) {
+                const seen = new Set<number | string>();
+                for (const val of values) {
+                  for await (const node of adapter.indexLookup(label, prop, val)) {
+                    if (!seen.has(node.id)) {
+                      seen.add(node.id);
+                      await collect(node);
+                    }
+                  }
+                }
+                usedIndex = true;
+              }
+            }
+          }
           if (!usedIndex) {
             const scan = adapter.scanNodes(plan.labels ? { labels: plan.labels } : {});
             for await (const node of scan) {

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -442,6 +442,13 @@ runOnAdapters('match with WHERE IN list', async engine => {
   assert.deepStrictEqual(out.sort(), ['Alice', 'Bob']);
 });
 
+runOnAdapters('match with parameterized IN', async engine => {
+  const q = "MATCH (n:Person) WHERE n.name IN $names RETURN n";
+  const out = [];
+  for await (const row of engine.run(q, { names: ["Alice", "Bob"] })) out.push(row.n.properties.name);
+  assert.deepStrictEqual(out.sort(), ["Alice", "Bob"]);
+});
+
 runOnAdapters('WHERE clause with parentheses', async engine => {
   const q =
     'MATCH (n:Person) WHERE (n.name = "Alice" OR n.name = "Bob") RETURN n';

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -72,3 +72,26 @@ test('index lookup faster than scan on large dataset', async () => {
 
   assert.ok(durIdx < durScan, `index ${durIdx} >= scan ${durScan}`);
 });
+
+test('planner uses index for WHERE IN list', async () => {
+  const data = makeDataset(10);
+  const adapter = new JsonAdapter({
+    dataset: data,
+    indexes: [{ label: 'Person', properties: ['name'], unique: true }]
+  });
+  let used = false;
+  const orig = adapter.indexLookup.bind(adapter);
+  adapter.indexLookup = async function*(label, prop, value) {
+    used = true;
+    for await (const n of orig(label, prop, value)) {
+      yield n;
+    }
+  };
+  const engine = new CypherEngine({ adapter });
+  const out = [];
+  for await (const row of engine.run('MATCH (n:Person) WHERE n.name IN ["name5"] RETURN n')) {
+    out.push(row.n);
+  }
+  assert.strictEqual(out.length, 1);
+  assert.ok(used);
+});


### PR DESCRIPTION
## Summary
- support index lookups when filtering with `IN`
- test parameterised IN query end-to-end
- test planner uses indexes for `WHERE IN` conditions

## Testing
- `npm test`