### PR TITLE
Support expression lists in Cypher parser

### DIFF
--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -14,6 +14,8 @@ function evalExpr(
   switch (expr.type) {
     case 'Literal':
       return expr.value;
+    case 'List':
+      return expr.items.map(i => evalExpr(i, vars, params));
     case 'Property': {
       const rec = vars.get(expr.variable) as NodeRecord | RelRecord | undefined;
       if (!rec) return undefined;
@@ -1595,13 +1597,8 @@ export function logicalToPhysical(
       }
       case 'Foreach': {
         const innerPlan = logicalToPhysical(plan.statement, adapter);
-        let items: unknown[];
-        if (Array.isArray(plan.list)) {
-          items = plan.list;
-        } else {
-          const v = evalExpr(plan.list, vars, params);
-          items = Array.isArray(v) ? v : [];
-        }
+        let items = evalExpr(plan.list, vars, params);
+        items = Array.isArray(items) ? items : [];
         for (const item of items) {
           vars.set(plan.variable, item);
           for await (const row of innerPlan(vars, params)) {
@@ -1612,13 +1609,8 @@ export function logicalToPhysical(
         break;
       }
       case 'Unwind': {
-        let items: unknown[];
-        if (Array.isArray(plan.list)) {
-          items = plan.list;
-        } else {
-          const v = evalExpr(plan.list, vars, params);
-          items = Array.isArray(v) ? v : [];
-        }
+        let items = evalExpr(plan.list, vars, params);
+        items = Array.isArray(items) ? items : [];
         for (const item of items) {
           vars.set(plan.variable, item);
           const val = evalExpr(plan.returnExpression, vars, params);

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -711,6 +711,12 @@ runOnAdapters('UNWIND with return alias', async engine => {
   assert.deepStrictEqual(out.sort(), [1, 2, 3]);
 });
 
+runOnAdapters('UNWIND array with expressions', async engine => {
+  const out = [];
+  for await (const row of engine.run('UNWIND [1, 1+1, 1+2] AS x RETURN x')) out.push(row.x);
+  assert.deepStrictEqual(out.sort(), [1, 2, 3]);
+});
+
 runOnAdapters('UNWIND nodes from path', async engine => {
   const script =
     'MATCH p=(a:Person {name:"Alice"})-[*]->(g:Genre {name:"Action"}) RETURN p; ' +
@@ -1111,6 +1117,13 @@ runOnAdapters('arithmetic multiplication and division in RETURN', async engine =
   const out = [];
   for await (const row of engine.run(q)) out.push(row.val);
   assert.deepStrictEqual(out, [((1999 - 1900) / 2) * 3, ((2014 - 1900) / 2) * 3]);
+});
+
+runOnAdapters('array expression in RETURN', async engine => {
+  const q = 'MATCH (p:Person {name:"Alice"}) RETURN [p.name, p.name + "!" ] AS arr';
+  const out = [];
+  for await (const row of engine.run(q)) out.push(row.arr);
+  assert.deepStrictEqual(out, [['Alice', 'Alice!']]);
 });
 runOnAdapters('RETURN star returns all variables', async engine => {
   const out = [];


### PR DESCRIPTION
## Summary
- add `List` expression type for array expressions
- parse arrays using full expressions
- simplify FOREACH and UNWIND list parsing
- evaluate `List` expressions in physical plan
- add e2e tests for array expressions
- remove accidentally added `package-lock.json`

## Testing
- `npm test`