### PR TITLE
Enable ID-based lookups

### DIFF
--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -95,3 +95,21 @@ test('planner uses index for WHERE IN list', async () => {
   assert.strictEqual(out.length, 1);
   assert.ok(used);
 });
+
+test('planner uses getNodeById for WHERE id(n) equality', async () => {
+  const data = makeDataset(10);
+  const adapter = new JsonAdapter({ dataset: data });
+  let used = false;
+  const orig = adapter.getNodeById.bind(adapter);
+  adapter.getNodeById = async id => {
+    used = true;
+    return await orig(id);
+  };
+  const engine = new CypherEngine({ adapter });
+  const out = [];
+  for await (const row of engine.run('MATCH (n) WHERE id(n) = 5 RETURN n')) {
+    out.push(row.n);
+  }
+  assert.strictEqual(out.length, 1);
+  assert.ok(used);
+});


### PR DESCRIPTION
## Summary
- use adapter.getNodeById when WHERE clause filters by id()
- test that the planner calls getNodeById for id() equality

## Testing
- `npm test`