### PR TITLE
Fix null arithmetic semantics

### DIFF
--- a/packages/core/src/physical/PhysicalPlan.ts
+++ b/packages/core/src/physical/PhysicalPlan.ts
@@ -31,6 +31,7 @@ function evalExpr(
     case 'Add':
       const l = evalExpr(expr.left, vars, params);
       const r = evalExpr(expr.right, vars, params);
+      if (l == null || r == null) return null;
       if (typeof l === 'number' && typeof r === 'number') {
         return l + r;
       }
@@ -38,6 +39,7 @@ function evalExpr(
     case 'Sub': {
       const l = evalExpr(expr.left, vars, params);
       const r = evalExpr(expr.right, vars, params);
+      if (l == null || r == null) return null;
       if (typeof l === 'number' && typeof r === 'number') {
         return l - r;
       }
@@ -46,6 +48,7 @@ function evalExpr(
     case 'Mul': {
       const l = evalExpr(expr.left, vars, params);
       const r = evalExpr(expr.right, vars, params);
+      if (l == null || r == null) return null;
       if (typeof l === 'number' && typeof r === 'number') {
         return l * r;
       }
@@ -54,6 +57,7 @@ function evalExpr(
     case 'Div': {
       const l = evalExpr(expr.left, vars, params);
       const r = evalExpr(expr.right, vars, params);
+      if (l == null || r == null) return null;
       if (typeof l === 'number' && typeof r === 'number') {
         return l / r;
       }
@@ -61,6 +65,7 @@ function evalExpr(
     }
     case 'Neg': {
       const v = evalExpr(expr.expression, vars, params);
+      if (v == null) return null;
       return typeof v === 'number' ? -v : NaN;
     }
     case 'Nodes':

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -1203,6 +1203,13 @@ runOnAdapters('NULL literal handled in create and match', async engine => {
   assert.strictEqual(out.length, 1);
 });
 
+runOnAdapters('NULL in arithmetic returns NULL', async engine => {
+  const q = 'RETURN null + 1 AS a, 1 + null AS b, null * 2 AS c, -null AS d';
+  const out = [];
+  for await (const row of engine.run(q)) out.push(row);
+  assert.deepStrictEqual(out, [{ a: null, b: null, c: null, d: null }]);
+});
+
 runOnAdapters('WITH passes variable to subsequent MATCH', async engine => {
   const q =
     'MATCH (p:Person {name:"Alice"}) WITH p MATCH (p)-[:ACTED_IN]->(m) RETURN m.title AS title';


### PR DESCRIPTION
## Summary
- handle `null` values correctly in arithmetic expressions
- add end-to-end test for null propagation

## Testing
- `npm test --silent`