### PR TITLE
Support size() function

### DIFF
--- a/packages/core/src/parser/CypherParser.ts
+++ b/packages/core/src/parser/CypherParser.ts
@@ -652,7 +652,7 @@ class Parser {
         this.consume('punct', ')');
         return { type: 'Relationships', variable: inner };
       }
-      if (tok.value === 'length' && this.lookahead()?.value === '(') {
+      if ((tok.value === 'length' || tok.value === 'size') && this.lookahead()?.value === '(') {
         this.pos++;
         this.consume('punct', '(');
         const inner = this.parseValue();

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -1288,3 +1288,24 @@ runOnAdapters('length() on string expression returns length', async engine => {
   for await (const row of engine.run(q)) out.push(row.len);
   assert.deepStrictEqual(out, [3]);
 });
+
+runOnAdapters('size() on list expression returns length', async engine => {
+  const q = 'RETURN size([1,2,3]) AS len';
+  const out = [];
+  for await (const row of engine.run(q)) out.push(row.len);
+  assert.deepStrictEqual(out, [3]);
+});
+
+runOnAdapters('size() on string expression returns length', async engine => {
+  const q = "RETURN size('abc') AS len";
+  const out = [];
+  for await (const row of engine.run(q)) out.push(row.len);
+  assert.deepStrictEqual(out, [3]);
+});
+
+runOnAdapters('size() on path returns hop count', async engine => {
+  const q = 'MATCH p=(a:Person {name:"Alice"})-[:ACTED_IN]->(m:Movie {title:"The Matrix"}) RETURN size(p) AS len';
+  const out = [];
+  for await (const row of engine.run(q)) out.push(row.len);
+  assert.deepStrictEqual(out, [1]);
+});


### PR DESCRIPTION
## Summary
- support `size()` as an alias for `length()`
- test size() on lists, strings and paths

## Testing
- `npm test`