### PR TITLE
Support multi-label transpilation

### DIFF
--- a/packages/adapters/sqljs-adapter/src/index.ts
+++ b/packages/adapters/sqljs-adapter/src/index.ts
@@ -540,7 +540,6 @@ export class SqlJsAdapter implements StorageAdapter {
     const matchAst = ast as MatchReturnQuery;
     if (
       matchAst.isRelationship ||
-      (matchAst.labels && matchAst.labels.length > 1) ||
       matchAst.optional
     )
       return null;
@@ -608,9 +607,11 @@ export class SqlJsAdapter implements StorageAdapter {
     let sql = 'SELECT id, labels, properties FROM nodes';
     const paramsArr: any[] = [];
     const conds: string[] = [];
-    if (matchAst.labels && matchAst.labels.length === 1) {
-      conds.push('labels LIKE ?');
-      paramsArr.push(`%"${matchAst.labels[0]}"%`);
+    if (matchAst.labels && matchAst.labels.length > 0) {
+      for (const lbl of matchAst.labels) {
+        conds.push('labels LIKE ?');
+        paramsArr.push(`%"${lbl}"%`);
+      }
     }
     if (matchAst.properties) {
       for (const [k, v] of Object.entries(matchAst.properties)) {

--- a/packages/adapters/sqljs-schema-adapter/src/index.ts
+++ b/packages/adapters/sqljs-schema-adapter/src/index.ts
@@ -170,7 +170,6 @@ export class SqlJsSchemaAdapter implements StorageAdapter {
     const matchAst = ast as MatchReturnQuery;
     if (
       matchAst.isRelationship ||
-      (matchAst.labels && matchAst.labels.length > 1) ||
       matchAst.orderBy ||
       matchAst.skip ||
       matchAst.limit ||
@@ -187,8 +186,10 @@ export class SqlJsSchemaAdapter implements StorageAdapter {
     let sql = `SELECT * FROM ${table.table}`;
     const paramsArr: any[] = [];
     const conds: string[] = [];
-    if (matchAst.labels && matchAst.labels.length === 1) {
-      if (table.labels && !table.labels.includes(matchAst.labels[0])) return null;
+    if (matchAst.labels && matchAst.labels.length > 0) {
+      if (table.labels && !matchAst.labels.every(l => table.labels!.includes(l))) {
+        return null;
+      }
     }
     if (conds.length > 0) sql += ' WHERE ' + conds.join(' AND ');
     const self = this;

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -168,17 +168,25 @@ runOnAdapters('create node with label', async engine => {
   assert.strictEqual(out.length, 1);
 });
 
-runOnAdapters('match by secondary label', async engine => {
+runOnAdapters('match by secondary label', async (engine, adapter) => {
+  const result = engine.run('MATCH (n:Actor) RETURN n');
   const out = [];
-  for await (const row of engine.run('MATCH (n:Actor) RETURN n')) out.push(row.n);
+  for await (const row of result) out.push(row.n);
   assert.strictEqual(out.length, 1);
+  if (adapter.supportsTranspilation) {
+    assert.strictEqual(result.meta.transpiled, true);
+  }
 });
 
-runOnAdapters('match with multiple labels', async engine => {
+runOnAdapters('match with multiple labels', async (engine, adapter) => {
+  const result = engine.run('MATCH (n:Person:Actor) RETURN n');
   const out = [];
-  for await (const row of engine.run('MATCH (n:Person:Actor) RETURN n')) out.push(row.n);
+  for await (const row of result) out.push(row.n);
   assert.strictEqual(out.length, 1);
   assert.strictEqual(out[0].properties.name, 'Carol');
+  if (adapter.supportsTranspilation) {
+    assert.strictEqual(result.meta.transpiled, true);
+  }
 });
 
 runOnAdapters('create node with multiple labels', async engine => {


### PR DESCRIPTION
## Summary
- expand SQL transpilation to handle multiple labels
- ensure schema adapter accepts multi-label matches
- verify in e2e tests that multiple label queries are transpiled

## Testing
- `npm test`