### PR TITLE
Extend transpiled SQL support

### DIFF
--- a/packages/adapters/sqljs-adapter/src/index.ts
+++ b/packages/adapters/sqljs-adapter/src/index.ts
@@ -886,7 +886,7 @@ export class SqlJsAdapter implements StorageAdapter {
 
     if (ast.type === 'MatchMultiReturn') {
       const multi = ast as MatchMultiReturnQuery;
-      if (multi.optional) return null;
+      const isOptional = multi.optional;
       for (const p of multi.patterns) {
         if (p.labels && p.labels.length > 1) return null;
       }
@@ -1005,7 +1005,12 @@ export class SqlJsAdapter implements StorageAdapter {
       }
 
       async function* genMulti() {
-        const sets = await Promise.all(multi.patterns.map(p => fetch(p)));
+        const sets = await Promise.all(
+          multi.patterns.map(async p => {
+            const res = await fetch(p);
+            return res.length === 0 && isOptional ? [undefined] : res;
+          })
+        );
 
         const hasAggItem = multi.returnItems.map(r => self.hasAgg(r.expression));
         const hasAgg = hasAggItem.some(v => v);
@@ -1095,6 +1100,21 @@ export class SqlJsAdapter implements StorageAdapter {
             }
             rows.push({ row: group.row, order });
           }
+        }
+
+        if (rows.length === 0 && isOptional && !hasAgg) {
+          const empty: Record<string, any> = {};
+          multi.returnItems.forEach((item, idx) => {
+            const alias = aliasFor(item, idx);
+            if (item.expression.type === 'All') {
+              vars.forEach(v => {
+                empty[v] = undefined;
+              });
+            } else {
+              empty[alias] = undefined;
+            }
+          });
+          rows.push({ row: empty });
         }
 
         if (multi.distinct) {

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -820,13 +820,17 @@ runOnAdapters('OPTIONAL MATCH existing node returns it', async (engine, adapter)
   }
 });
 
-runOnAdapters('OPTIONAL MATCH multiple patterns returns partial row', async engine => {
+runOnAdapters('OPTIONAL MATCH multiple patterns returns partial row', async (engine, adapter) => {
   const q = 'OPTIONAL MATCH (p:Person {name:"Missing"}), (m:Movie {title:"The Matrix"}) RETURN p, m';
+  const result = engine.run(q);
   const out = [];
-  for await (const row of engine.run(q)) out.push(row);
+  for await (const row of result) out.push(row);
   assert.strictEqual(out.length, 1);
   assert.strictEqual(out[0].m.properties.title, 'The Matrix');
   assert.strictEqual(out[0].p, undefined);
+  if (adapter.supportsTranspilation) {
+    assert.strictEqual(result.meta.transpiled, true);
+  }
 });
 
 runOnAdapters('OPTIONAL MATCH relationship chain missing returns null row', async engine => {


### PR DESCRIPTION
## Summary
- extend `SqlJsAdapter` transpiler to handle OPTIONAL MATCH with multiple patterns
- add corresponding e2e test assertion for transpilation metadata

## Testing
- `npm test`