### PR TITLE
Improve transpiled query support

### DIFF
--- a/packages/adapters/sqljs-adapter/src/index.ts
+++ b/packages/adapters/sqljs-adapter/src/index.ts
@@ -547,7 +547,7 @@ export class SqlJsAdapter implements StorageAdapter {
   ): AsyncIterable<Record<string, unknown>> | null {
     if (ast.type === 'MatchReturn') {
       const matchAst = ast as MatchReturnQuery;
-    if (matchAst.labels && matchAst.labels.length > 1) return null;
+    // allow multi-label node matches by requiring each label to be present
     if (matchAst.isRelationship) {
       if (matchAst.where || matchAst.orderBy || matchAst.skip || matchAst.limit || matchAst.distinct)
         return null;
@@ -680,9 +680,11 @@ export class SqlJsAdapter implements StorageAdapter {
     let sql = 'SELECT id, labels, properties FROM nodes';
     const paramsArr: any[] = [];
     const conds: string[] = [];
-    if (matchAst.labels && matchAst.labels.length === 1) {
-      conds.push('labels LIKE ?');
-      paramsArr.push(`%"${matchAst.labels[0]}"%`);
+    if (matchAst.labels && matchAst.labels.length > 0) {
+      for (const lbl of matchAst.labels) {
+        conds.push('labels LIKE ?');
+        paramsArr.push(`%"${lbl}"%`);
+      }
     }
     if (matchAst.properties) {
       for (const [k, v] of Object.entries(matchAst.properties)) {
@@ -958,9 +960,7 @@ export class SqlJsAdapter implements StorageAdapter {
     if (ast.type === 'MatchMultiReturn') {
       const multi = ast as MatchMultiReturnQuery;
       const isOptional = multi.optional;
-      for (const p of multi.patterns) {
-        if (p.labels && p.labels.length > 1) return null;
-      }
+      // allow multi-label patterns in MATCH by checking all labels
       const vars = multi.patterns.map(p => p.variable);
       function checkExpr(expr: Expression): boolean {
         switch (expr.type) {
@@ -1005,9 +1005,11 @@ export class SqlJsAdapter implements StorageAdapter {
         let sql = 'SELECT id, labels, properties FROM nodes';
         const paramsArr: any[] = [];
         const conds: string[] = [];
-        if (p.labels && p.labels.length === 1) {
-          conds.push('labels LIKE ?');
-          paramsArr.push(`%"${p.labels[0]}"%`);
+        if (p.labels && p.labels.length > 0) {
+          for (const lbl of p.labels) {
+            conds.push('labels LIKE ?');
+            paramsArr.push(`%"${lbl}"%`);
+          }
         }
         if (p.properties) {
           for (const [k, v] of Object.entries(p.properties)) {

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -178,11 +178,15 @@ runOnAdapters('match by secondary label', async engine => {
   assert.strictEqual(out.length, 1);
 });
 
-runOnAdapters('match with multiple labels', async engine => {
+runOnAdapters('match with multiple labels', async (engine, adapter) => {
   const out = [];
-  for await (const row of engine.run('MATCH (n:Person:Actor) RETURN n')) out.push(row.n);
+  const result = engine.run('MATCH (n:Person:Actor) RETURN n');
+  for await (const row of result) out.push(row.n);
   assert.strictEqual(out.length, 1);
   assert.strictEqual(out[0].properties.name, 'Carol');
+  if (adapter.supportsTranspilation) {
+    assert.strictEqual(result.meta.transpiled, true);
+  }
 });
 
 runOnAdapters('create node with multiple labels', async engine => {


### PR DESCRIPTION
## Summary
- support multi-label node matches in SQL transpiler
- verify that multi-label matches are transpiled

## Testing
- `npm test`