### PR TITLE
Expand transpilation coverage in e2e tests

### DIFF
--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -172,10 +172,14 @@ runOnAdapters('create node with label', async engine => {
   assert.strictEqual(out.length, 1);
 });
 
-runOnAdapters('match by secondary label', async engine => {
+runOnAdapters('match by secondary label', async (engine, adapter) => {
+  const result = engine.run('MATCH (n:Actor) RETURN n');
   const out = [];
-  for await (const row of engine.run('MATCH (n:Actor) RETURN n')) out.push(row.n);
+  for await (const row of result) out.push(row.n);
   assert.strictEqual(out.length, 1);
+  if (adapter.supportsTranspilation) {
+    assert.strictEqual(result.meta.transpiled, true);
+  }
 });
 
 runOnAdapters('match with multiple labels', async (engine, adapter) => {


### PR DESCRIPTION
## Summary
- check transpilation meta flag when matching by secondary label

## Testing
- `npm test`