### PR TITLE
Expand SQL transpiler support

### DIFF
--- a/packages/adapters/sqljs-adapter/src/index.ts
+++ b/packages/adapters/sqljs-adapter/src/index.ts
@@ -328,8 +328,15 @@ export class SqlJsAdapter implements StorageAdapter {
         return rec ? rec.id : undefined;
       }
       case 'Length': {
-        const v = this.evalExpr(expr.expression, vars, params);
-        if (v == null) return null;
+        let v: any;
+        if (expr.expression.type === 'Variable') {
+          v = vars.get(expr.expression.name);
+        } else {
+          v = this.evalExpr(expr.expression, vars, params);
+        }
+        if (v && typeof v === 'object' && 'relationships' in v) {
+          return (v as any).relationships.length;
+        }
         if (Array.isArray(v) || typeof v === 'string') return v.length;
         return undefined;
       }
@@ -559,6 +566,8 @@ export class SqlJsAdapter implements StorageAdapter {
           case 'Property':
           case 'Id':
           case 'Labels':
+            return expr.variable === matchAst.variable;
+          case 'Type':
             return expr.variable === matchAst.variable;
           case 'Literal':
           case 'Parameter':
@@ -1059,6 +1068,7 @@ export class SqlJsAdapter implements StorageAdapter {
           case 'Property':
           case 'Id':
           case 'Labels':
+          case 'Type':
             return vars.includes(expr.variable);
           case 'Literal':
           case 'Parameter':
@@ -1337,14 +1347,14 @@ export class SqlJsAdapter implements StorageAdapter {
         chain.skip ||
         chain.limit ||
         chain.distinct ||
-        chain.optional ||
-        chain.pathVariable
+        chain.optional
       )
         return null;
       const hop = chain.hops[0];
       if (hop.rel.direction === 'none') return null;
       const vars = [chain.start.variable, hop.node.variable];
       if (hop.rel.variable) vars.push(hop.rel.variable);
+      if (chain.pathVariable) vars.push(chain.pathVariable);
       function checkExpr(expr: Expression): boolean {
         switch (expr.type) {
           case 'Variable':
@@ -1352,6 +1362,7 @@ export class SqlJsAdapter implements StorageAdapter {
           case 'Property':
           case 'Id':
           case 'Labels':
+          case 'Type':
             return vars.includes(expr.variable);
           case 'Literal':
           case 'Parameter':
@@ -1530,6 +1541,9 @@ export class SqlJsAdapter implements StorageAdapter {
           varsMap.set(chain.start.variable, n1);
           varsMap.set(hop.node.variable, n2);
           if (hop.rel.variable) varsMap.set(hop.rel.variable, rel);
+          if (chain.pathVariable) {
+            varsMap.set(chain.pathVariable, { nodes: [n1, n2], relationships: [rel] });
+          }
           if (chain.where && !evalWhere(chain.where, varsMap)) continue;
           const outRow: Record<string, any> = {};
           chain.returnItems.forEach((item: any, idx: number) => {

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -1446,15 +1446,19 @@ runOnAdapters('RETURN star returns all variables', async (engine, adapter) => {
   }
 });
 
-runOnAdapters('RETURN star with relationship chain', async engine => {
+runOnAdapters('RETURN star with relationship chain', async (engine, adapter) => {
   const q = 'MATCH (p:Person {name:"Alice"})-[r:ACTED_IN]->(m:Movie {title:"John Wick"}) RETURN *';
+  const result = engine.run(q);
   const out = [];
-  for await (const row of engine.run(q)) out.push(row);
+  for await (const row of result) out.push(row);
   assert.strictEqual(out.length, 1);
   assert.ok(out[0].p && out[0].r && out[0].m);
   assert.strictEqual(out[0].p.properties.name, 'Alice');
   assert.strictEqual(out[0].m.properties.title, 'John Wick');
   assert.strictEqual(out[0].r.type, 'ACTED_IN');
+  if (adapter.supportsTranspilation) {
+    assert.strictEqual(result.meta.transpiled, true);
+  }
 });
 runOnAdapters('id() function returns node id', async (engine, adapter) => {
   const result = engine.run('MATCH (n:Person {name:"Alice"}) RETURN id(n) AS id');
@@ -1466,18 +1470,26 @@ runOnAdapters('id() function returns node id', async (engine, adapter) => {
   }
 });
 
-runOnAdapters('id() on relationship returns rel id', async engine => {
-  const out = [];
+runOnAdapters('id() on relationship returns rel id', async (engine, adapter) => {
   const q = 'MATCH ()-[r:ACTED_IN {role:"Neo"}]->() RETURN id(r) AS id';
-  for await (const row of engine.run(q)) out.push(row.id);
+  const result = engine.run(q);
+  const out = [];
+  for await (const row of result) out.push(row.id);
   assert.deepStrictEqual(out, [7]);
+  if (adapter.supportsTranspilation) {
+    assert.strictEqual(result.meta.transpiled, true);
+  }
 });
 
-runOnAdapters('type() on relationship returns rel type', async engine => {
-  const out = [];
+runOnAdapters('type() on relationship returns rel type', async (engine, adapter) => {
   const q = 'MATCH ()-[r:ACTED_IN {role:"Neo"}]->() RETURN type(r) AS type';
-  for await (const row of engine.run(q)) out.push(row.type);
+  const result = engine.run(q);
+  const out = [];
+  for await (const row of result) out.push(row.type);
   assert.deepStrictEqual(out, ['ACTED_IN']);
+  if (adapter.supportsTranspilation) {
+    assert.strictEqual(result.meta.transpiled, true);
+  }
 });
 
 runOnAdapters('labels() function returns node labels', async (engine, adapter) => {
@@ -1653,9 +1665,13 @@ runOnAdapters('size() on string expression returns length', async (engine, adapt
   }
 });
 
-runOnAdapters('size() on path returns hop count', async engine => {
+runOnAdapters('size() on path returns hop count', async (engine, adapter) => {
   const q = 'MATCH p=(a:Person {name:"Alice"})-[:ACTED_IN]->(m:Movie {title:"The Matrix"}) RETURN size(p) AS len';
+  const result = engine.run(q);
   const out = [];
-  for await (const row of engine.run(q)) out.push(row.len);
+  for await (const row of result) out.push(row.len);
   assert.deepStrictEqual(out, [1]);
+  if (adapter.supportsTranspilation) {
+    assert.strictEqual(result.meta.transpiled, true);
+  }
 });


### PR DESCRIPTION
## Summary
- allow returning `type()` from relationship matches
- support path variables in single-hop chains
- fix size/length on paths for SQL transpiler
- assert transpilation in more e2e cases

## Testing
- `npm test`