### PR TITLE
Expand SQL transpiler tests

### DIFF
--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -951,6 +951,7 @@ runOnAdapters('chain match with parameter property', async engine => {
 
 runOnAdapters('COUNT aggregation', async (engine, adapter) => {
   const result = engine.run('MATCH (m:Movie) RETURN COUNT(m)');
+  assert.strictEqual(result.meta.transpiled, !!adapter.supportsTranspilation);
   const out = [];
   for await (const row of result) out.push(row.value);
   assert.strictEqual(out[0], 2);
@@ -958,14 +959,17 @@ runOnAdapters('COUNT aggregation', async (engine, adapter) => {
 
 runOnAdapters('COUNT on empty result returns 0', async (engine, adapter) => {
   const result = engine.run('MATCH (n:Missing) RETURN COUNT(n) AS cnt');
+  assert.strictEqual(result.meta.transpiled, !!adapter.supportsTranspilation);
   const out = [];
   for await (const row of result) out.push(row.cnt);
   assert.deepStrictEqual(out, [0]);
 });
 
-runOnAdapters('OPTIONAL MATCH with COUNT returns 0', async engine => {
+runOnAdapters('OPTIONAL MATCH with COUNT returns 0', async (engine, adapter) => {
+  const result = engine.run('OPTIONAL MATCH (n:Missing) RETURN COUNT(n) AS cnt');
+  assert.strictEqual(result.meta.transpiled, !!adapter.supportsTranspilation);
   const out = [];
-  for await (const row of engine.run('OPTIONAL MATCH (n:Missing) RETURN COUNT(n) AS cnt')) out.push(row.cnt);
+  for await (const row of result) out.push(row.cnt);
   assert.deepStrictEqual(out, [0]);
 });
 

--- a/tests/transpile.test.js
+++ b/tests/transpile.test.js
@@ -347,6 +347,27 @@ test('transpile with negative comparison', () => {
   assert.deepStrictEqual(result.params, ['%"Person"%', -5]);
 });
 
+test('transpile COUNT nodes', () => {
+  const result = adapter.transpile('MATCH (n:Person) RETURN COUNT(n)');
+  assert.ok(result);
+  assert.strictEqual(
+    result.sql,
+    'SELECT COUNT(*) AS value FROM nodes WHERE labels LIKE ?'
+  );
+  assert.deepStrictEqual(result.params, ['%"Person"%']);
+});
+
+test('transpile COUNT with WHERE clause', () => {
+  const q = 'MATCH (n:Person) WHERE n.age > 30 RETURN COUNT(n) AS cnt';
+  const result = adapter.transpile(q);
+  assert.ok(result);
+  assert.strictEqual(
+    result.sql,
+    'SELECT COUNT(*) AS value FROM nodes WHERE labels LIKE ? AND json_extract(properties, \'$.age\') > ?'
+  );
+  assert.deepStrictEqual(result.params, ['%"Person"%', 30]);
+});
+
 test('transpile returns null for ORDER BY', () => {
   const q = 'MATCH (n:Person) RETURN n ORDER BY n.name';
   const result = adapter.transpile(q);


### PR DESCRIPTION
## Summary
- support transpilation of `COUNT()` in SqlJs adapter
- test COUNT transpilation cases
- check transpilation metadata for COUNT e2e tests

## Testing
- `npm test`