### PR TITLE
Add id-based transpile tests and support

### DIFF
--- a/packages/adapters/sqljs-adapter/src/index.ts
+++ b/packages/adapters/sqljs-adapter/src/index.ts
@@ -625,9 +625,17 @@ export class SqlJsAdapter implements StorageAdapter {
     function convertWhere(where: any): [string, any[]] | null {
       if (!where) return ['1', []];
       if (where.type === 'Condition') {
-        if (where.left.type !== 'Property' || where.left.variable !== matchAst.variable)
+        let col: string | null = null;
+        const left = where.left;
+        let isId = false;
+        if (left.type === 'Property' && left.variable === matchAst.variable) {
+          col = `json_extract(properties, '$.${left.property}')`;
+        } else if (left.type === 'Id' && left.variable === matchAst.variable) {
+          col = 'id';
+          isId = true;
+        } else {
           return null;
-        const col = `json_extract(properties, '$.${where.left.property}')`;
+        }
         switch (where.operator) {
           case '=':
           case '<>': {
@@ -657,20 +665,25 @@ export class SqlJsAdapter implements StorageAdapter {
             return [`${col} IN (${placeholders})`, val];
           }
           case 'IS NULL':
+            if (isId) return null;
             return [`${col} IS NULL`, []];
           case 'IS NOT NULL':
+            if (isId) return null;
             return [`${col} IS NOT NULL`, []];
           case 'STARTS WITH': {
+            if (isId) return null;
             const val = toValue(where.right);
             if (typeof val !== 'string') return null;
             return [`${col} LIKE ?`, [val + '%']];
           }
           case 'ENDS WITH': {
+            if (isId) return null;
             const val = toValue(where.right);
             if (typeof val !== 'string') return null;
             return [`${col} LIKE ?`, ['%' + val]];
           }
           case 'CONTAINS': {
+            if (isId) return null;
             const val = toValue(where.right);
             if (typeof val !== 'string') return null;
             return [`${col} LIKE ?`, ['%' + val + '%']];

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -182,6 +182,15 @@ runOnAdapters('match with multiple labels', async (engine, adapter) => {
   assert.strictEqual(out[0].properties.name, 'Carol');
 });
 
+runOnAdapters('match node by id', async (engine, adapter) => {
+  const result = engine.run('MATCH (n:Person) WHERE id(n) = 1 RETURN n');
+  assert.strictEqual(result.meta.transpiled, !!adapter.supportsTranspilation);
+  const out = [];
+  for await (const row of result) out.push(row.n);
+  assert.strictEqual(out.length, 1);
+  assert.strictEqual(out[0].properties.name, 'Alice');
+});
+
 runOnAdapters('create node with multiple labels', async engine => {
   let node;
   for await (const row of engine.run('CREATE (n:Multi:One {v:1}) RETURN n')) node = row.n;

--- a/tests/transpile.test.js
+++ b/tests/transpile.test.js
@@ -364,3 +364,47 @@ test('transpile returns null for relationship match', () => {
   const result = adapter.transpile(q);
   assert.strictEqual(result, null);
 });
+
+test('transpile WHERE id equality', () => {
+  const q = 'MATCH (n:Person) WHERE id(n) = 1 RETURN n';
+  const result = adapter.transpile(q);
+  assert.ok(result);
+  assert.strictEqual(
+    result.sql,
+    'SELECT id, labels, properties FROM nodes WHERE labels LIKE ? AND id = ?'
+  );
+  assert.deepStrictEqual(result.params, ['%"Person"%', 1]);
+});
+
+test('transpile WHERE id IN list', () => {
+  const q = 'MATCH (n) WHERE id(n) IN [1,2] RETURN n';
+  const result = adapter.transpile(q);
+  assert.ok(result);
+  assert.strictEqual(
+    result.sql,
+    'SELECT id, labels, properties FROM nodes WHERE id IN (?, ?)'
+  );
+  assert.deepStrictEqual(result.params, [1, 2]);
+});
+
+test('transpile WHERE id IN empty list', () => {
+  const q = 'MATCH (n:Person) WHERE id(n) IN [] RETURN n';
+  const result = adapter.transpile(q);
+  assert.ok(result);
+  assert.strictEqual(
+    result.sql,
+    'SELECT id, labels, properties FROM nodes WHERE labels LIKE ? AND 0'
+  );
+  assert.deepStrictEqual(result.params, ['%"Person"%']);
+});
+
+test('transpile WHERE id equality parameter', () => {
+  const q = 'MATCH (n) WHERE id(n) = $id RETURN n';
+  const result = adapter.transpile(q, { id: 3 });
+  assert.ok(result);
+  assert.strictEqual(
+    result.sql,
+    'SELECT id, labels, properties FROM nodes WHERE id = ?'
+  );
+  assert.deepStrictEqual(result.params, [3]);
+});


### PR DESCRIPTION
## Summary
- add transpiler unit tests for `id()` conditions
- enable matching nodes by `id` in SQL transpiler
- check transpilation for id-based match in e2e tests

## Testing
- `npm test`