### PR TITLE
Extend SQL transpiler ordering

### DIFF
--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -859,6 +859,7 @@ runOnAdapters('OPTIONAL MATCH relationship chain missing returns null row', asyn
 runOnAdapters('ORDER BY with SKIP and LIMIT', async (engine, adapter) => {
   const q = 'MATCH (n:Person) RETURN n.name AS name ORDER BY n.name SKIP 1 LIMIT 1';
   const result = engine.run(q);
+  assert.strictEqual(result.meta.transpiled, !!adapter.supportsTranspilation);
   const out = [];
   for await (const row of result) out.push(row.name);
   assert.deepStrictEqual(out, ['Bob']);
@@ -867,6 +868,7 @@ runOnAdapters('ORDER BY with SKIP and LIMIT', async (engine, adapter) => {
 runOnAdapters('ORDER BY DESC', async (engine, adapter) => {
   const q = 'MATCH (m:Movie) RETURN m.released AS year ORDER BY year DESC';
   const result = engine.run(q);
+  assert.strictEqual(result.meta.transpiled, !!adapter.supportsTranspilation);
   const out = [];
   for await (const row of result) out.push(row.year);
   assert.deepStrictEqual(out, [2014, 1999]);
@@ -893,6 +895,7 @@ runOnAdapters('RETURN multiple expressions with aliases', async (engine, adapter
 runOnAdapters('LIMIT with parameter', async (engine, adapter) => {
   const q = 'MATCH (n:Person) RETURN n.name AS name ORDER BY name LIMIT $lim';
   const result = engine.run(q, { lim: 2 });
+  assert.strictEqual(result.meta.transpiled, !!adapter.supportsTranspilation);
   const out = [];
   for await (const row of result) out.push(row.name);
   assert.deepStrictEqual(out, ['Alice', 'Bob']);
@@ -901,6 +904,7 @@ runOnAdapters('LIMIT with parameter', async (engine, adapter) => {
 runOnAdapters('SKIP with parameter', async (engine, adapter) => {
   const q = 'MATCH (n:Person) RETURN n.name AS name ORDER BY name SKIP $s';
   const result = engine.run(q, { s: 1 });
+  assert.strictEqual(result.meta.transpiled, !!adapter.supportsTranspilation);
   const out = [];
   for await (const row of result) out.push(row.name);
   assert.deepStrictEqual(out, ['Bob', 'Carol']);

--- a/tests/transpile.test.js
+++ b/tests/transpile.test.js
@@ -368,16 +368,26 @@ test('transpile COUNT with WHERE clause', () => {
   assert.deepStrictEqual(result.params, ['%"Person"%', 30]);
 });
 
-test('transpile returns null for ORDER BY', () => {
+test('transpile ORDER BY property', () => {
   const q = 'MATCH (n:Person) RETURN n ORDER BY n.name';
   const result = adapter.transpile(q);
-  assert.strictEqual(result, null);
+  assert.ok(result);
+  assert.strictEqual(
+    result.sql,
+    "SELECT id, labels, properties FROM nodes WHERE labels LIKE ? ORDER BY json_extract(properties, '$.name')"
+  );
+  assert.deepStrictEqual(result.params, ['%"Person"%']);
 });
 
-test('transpile returns null for LIMIT', () => {
+test('transpile LIMIT nodes', () => {
   const q = 'MATCH (n:Person) RETURN n LIMIT 1';
   const result = adapter.transpile(q);
-  assert.strictEqual(result, null);
+  assert.ok(result);
+  assert.strictEqual(
+    result.sql,
+    'SELECT id, labels, properties FROM nodes WHERE labels LIKE ? LIMIT 1'
+  );
+  assert.deepStrictEqual(result.params, ['%"Person"%']);
 });
 
 test('transpile returns null for relationship match', () => {
@@ -428,4 +438,37 @@ test('transpile WHERE id equality parameter', () => {
     'SELECT id, labels, properties FROM nodes WHERE id = ?'
   );
   assert.deepStrictEqual(result.params, [3]);
+});
+
+test('transpile return property with ORDER BY', () => {
+  const q = 'MATCH (n:Person) RETURN n.name AS name ORDER BY name DESC';
+  const result = adapter.transpile(q);
+  assert.ok(result);
+  assert.strictEqual(
+    result.sql,
+    "SELECT json_extract(properties, '$.name') AS value FROM nodes WHERE labels LIKE ? ORDER BY json_extract(properties, '$.name') DESC"
+  );
+  assert.deepStrictEqual(result.params, ['%"Person"%']);
+});
+
+test('transpile ORDER BY with SKIP and LIMIT', () => {
+  const q = 'MATCH (n:Person) RETURN n.name AS name ORDER BY name SKIP 1 LIMIT 2';
+  const result = adapter.transpile(q);
+  assert.ok(result);
+  assert.strictEqual(
+    result.sql,
+    "SELECT json_extract(properties, '$.name') AS value FROM nodes WHERE labels LIKE ? ORDER BY json_extract(properties, '$.name') LIMIT 2 OFFSET 1"
+  );
+  assert.deepStrictEqual(result.params, ['%"Person"%']);
+});
+
+test('transpile RETURN node with LIMIT', () => {
+  const q = 'MATCH (n:Person) RETURN n LIMIT 1';
+  const result = adapter.transpile(q);
+  assert.ok(result);
+  assert.strictEqual(
+    result.sql,
+    'SELECT id, labels, properties FROM nodes WHERE labels LIKE ? LIMIT 1'
+  );
+  assert.deepStrictEqual(result.params, ['%"Person"%']);
 });


### PR DESCRIPTION
## Summary
- expand SQL transpilation with ORDER BY / SKIP / LIMIT and property returns
- add new unit tests exercising the additional transpilation features
- enable transpilation check for several e2e ORDER BY tests

## Testing
- `npm test`