### PR TITLE
Add more transpilation tests

### DIFF
--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -191,6 +191,24 @@ runOnAdapters('match node by id', async (engine, adapter) => {
   assert.strictEqual(out[0].properties.name, 'Alice');
 });
 
+runOnAdapters('match nodes by id list', async (engine, adapter) => {
+  const q = 'MATCH (n) WHERE id(n) IN [1,2] RETURN n';
+  const result = engine.run(q);
+  assert.strictEqual(result.meta.transpiled, !!adapter.supportsTranspilation);
+  const ids = [];
+  for await (const row of result) ids.push(row.n.id);
+  assert.deepStrictEqual(ids.sort(), [1, 2]);
+});
+
+runOnAdapters('match nodes by parameterized id list', async (engine, adapter) => {
+  const q = 'MATCH (n) WHERE id(n) IN $ids RETURN n';
+  const result = engine.run(q, { ids: [1, 2] });
+  assert.strictEqual(result.meta.transpiled, !!adapter.supportsTranspilation);
+  const ids = [];
+  for await (const row of result) ids.push(row.n.id);
+  assert.deepStrictEqual(ids.sort(), [1, 2]);
+});
+
 runOnAdapters('create node with multiple labels', async engine => {
   let node;
   for await (const row of engine.run('CREATE (n:Multi:One {v:1}) RETURN n')) node = row.n;

--- a/tests/transpile.test.js
+++ b/tests/transpile.test.js
@@ -429,3 +429,47 @@ test('transpile WHERE id equality parameter', () => {
   );
   assert.deepStrictEqual(result.params, [3]);
 });
+
+test('transpile WHERE id greater than constant', () => {
+  const q = 'MATCH (n) WHERE id(n) > 2 RETURN n';
+  const result = adapter.transpile(q);
+  assert.ok(result);
+  assert.strictEqual(
+    result.sql,
+    'SELECT id, labels, properties FROM nodes WHERE id > ?'
+  );
+  assert.deepStrictEqual(result.params, [2]);
+});
+
+test('transpile WHERE id not equal', () => {
+  const q = 'MATCH (n) WHERE id(n) <> 1 RETURN n';
+  const result = adapter.transpile(q);
+  assert.ok(result);
+  assert.strictEqual(
+    result.sql,
+    'SELECT id, labels, properties FROM nodes WHERE id <> ?'
+  );
+  assert.deepStrictEqual(result.params, [1]);
+});
+
+test('transpile WHERE id IN parameter list', () => {
+  const q = 'MATCH (n) WHERE id(n) IN $ids RETURN n';
+  const result = adapter.transpile(q, { ids: [1, 2] });
+  assert.ok(result);
+  assert.strictEqual(
+    result.sql,
+    'SELECT id, labels, properties FROM nodes WHERE id IN (?, ?)'
+  );
+  assert.deepStrictEqual(result.params, [1, 2]);
+});
+
+test('transpile WHERE id >= parameter', () => {
+  const q = 'MATCH (n) WHERE id(n) >= $min RETURN n';
+  const result = adapter.transpile(q, { min: 1 });
+  assert.ok(result);
+  assert.strictEqual(
+    result.sql,
+    'SELECT id, labels, properties FROM nodes WHERE id >= ?'
+  );
+  assert.deepStrictEqual(result.params, [1]);
+});


### PR DESCRIPTION
## Summary
- add coverage for more id-based transpile cases
- ensure id list matching uses transpilation in e2e tests

## Testing
- `npm test`