### PR TITLE
Enhance SQL transpilation for aggregations

### DIFF
--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -1059,6 +1059,7 @@ runOnAdapters('COLLECT aggregation returns list', async (engine, adapter) => {
 runOnAdapters('MIN aggregation', async (engine, adapter) => {
   const q = 'MATCH (m:Movie) RETURN MIN(m.released) AS year';
   const result = engine.run(q);
+  assert.strictEqual(result.meta.transpiled, !!adapter.supportsTranspilation);
   const out = [];
   for await (const row of result) out.push(row.year);
   assert.deepStrictEqual(out, [1999]);
@@ -1067,6 +1068,7 @@ runOnAdapters('MIN aggregation', async (engine, adapter) => {
 runOnAdapters('MAX aggregation', async (engine, adapter) => {
   const q = 'MATCH (m:Movie) RETURN MAX(m.released) AS year';
   const result = engine.run(q);
+  assert.strictEqual(result.meta.transpiled, !!adapter.supportsTranspilation);
   const out = [];
   for await (const row of result) out.push(row.year);
   assert.deepStrictEqual(out, [2014]);
@@ -1075,6 +1077,7 @@ runOnAdapters('MAX aggregation', async (engine, adapter) => {
 runOnAdapters('MIN on empty result returns null', async (engine, adapter) => {
   const q = 'MATCH (n:Missing) RETURN MIN(n.x) AS val';
   const result = engine.run(q);
+  assert.strictEqual(result.meta.transpiled, !!adapter.supportsTranspilation);
   const out = [];
   for await (const row of result) out.push(row.val);
   assert.deepStrictEqual(out, [null]);

--- a/tests/transpile.test.js
+++ b/tests/transpile.test.js
@@ -527,3 +527,36 @@ test('transpile multiple return properties', () => {
   );
   assert.deepStrictEqual(result.params, ['%"Movie"%']);
 });
+
+test('transpile MIN aggregation', () => {
+  const q = 'MATCH (m:Movie) RETURN MIN(m.released)';
+  const result = adapter.transpile(q);
+  assert.ok(result);
+  assert.strictEqual(
+    result.sql,
+    "SELECT MIN(json_extract(properties, '$.released')) AS value FROM nodes WHERE labels LIKE ?"
+  );
+  assert.deepStrictEqual(result.params, ['%"Movie"%']);
+});
+
+test('transpile MAX aggregation with alias', () => {
+  const q = 'MATCH (m:Movie) RETURN MAX(m.released) AS mx';
+  const result = adapter.transpile(q);
+  assert.ok(result);
+  assert.strictEqual(
+    result.sql,
+    "SELECT MAX(json_extract(properties, '$.released')) AS mx FROM nodes WHERE labels LIKE ?"
+  );
+  assert.deepStrictEqual(result.params, ['%"Movie"%']);
+});
+
+test('transpile SUM aggregation', () => {
+  const q = 'MATCH (m:Movie) RETURN SUM(m.released) AS total';
+  const result = adapter.transpile(q);
+  assert.ok(result);
+  assert.strictEqual(
+    result.sql,
+    "SELECT SUM(json_extract(properties, '$.released')) AS total FROM nodes WHERE labels LIKE ?"
+  );
+  assert.deepStrictEqual(result.params, ['%"Movie"%']);
+});


### PR DESCRIPTION
## Summary
- extend SQL transpiler to support `MIN`, `MAX` and `SUM`
- return aggregation results from `runTranspiled`
- add unit tests for new aggregation transpilation
- re-enable transpilation checks for aggregation e2e tests

## Testing
- `npm test`