### PR TITLE
Extend transpilation tests and support ORDER BY id

### DIFF
--- a/packages/adapters/sqljs-adapter/src/index.ts
+++ b/packages/adapters/sqljs-adapter/src/index.ts
@@ -766,6 +766,11 @@ export class SqlJsAdapter implements StorageAdapter {
             exprSql = `json_extract(properties, '$.${prop}')`;
           }
         } else if (
+          ob.expression.type === 'Id' &&
+          ob.expression.variable === matchAst.variable
+        ) {
+          exprSql = 'id';
+        } else if (
           ob.expression.type === 'Property' &&
           ob.expression.variable === matchAst.variable
         ) {

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -874,6 +874,15 @@ runOnAdapters('ORDER BY DESC', async (engine, adapter) => {
   assert.deepStrictEqual(out, [2014, 1999]);
 });
 
+runOnAdapters('ORDER BY id function', async (engine, adapter) => {
+  const q = 'MATCH (n:Person) RETURN n.name AS name ORDER BY id(n) DESC';
+  const result = engine.run(q);
+  assert.strictEqual(result.meta.transpiled, !!adapter.supportsTranspilation);
+  const out = [];
+  for await (const row of result) out.push(row.name);
+  assert.deepStrictEqual(out, ['Carol', 'Bob', 'Alice']);
+});
+
 runOnAdapters('ORDER BY multiple expressions', async (engine, adapter) => {
   for await (const _ of engine.run('CREATE (m:Movie {title:"Extra", released:2014})')) {}
   const q =

--- a/tests/transpile.test.js
+++ b/tests/transpile.test.js
@@ -527,3 +527,47 @@ test('transpile multiple return properties', () => {
   );
   assert.deepStrictEqual(result.params, ['%"Movie"%']);
 });
+
+test('transpile ORDER BY id function', () => {
+  const q = 'MATCH (n:Person) RETURN n ORDER BY id(n) DESC';
+  const result = adapter.transpile(q);
+  assert.ok(result);
+  assert.strictEqual(
+    result.sql,
+    'SELECT id, labels, properties FROM nodes WHERE labels LIKE ? ORDER BY id DESC'
+  );
+  assert.deepStrictEqual(result.params, ['%"Person"%']);
+});
+
+test('transpile ORDER BY variable', () => {
+  const q = 'MATCH (n:Person) RETURN n ORDER BY n';
+  const result = adapter.transpile(q);
+  assert.ok(result);
+  assert.strictEqual(
+    result.sql,
+    'SELECT id, labels, properties FROM nodes WHERE labels LIKE ? ORDER BY id'
+  );
+  assert.deepStrictEqual(result.params, ['%"Person"%']);
+});
+
+test('transpile ORDER BY return alias', () => {
+  const q = 'MATCH (n:Person) RETURN n.name AS nm ORDER BY nm';
+  const result = adapter.transpile(q);
+  assert.ok(result);
+  assert.strictEqual(
+    result.sql,
+    "SELECT json_extract(properties, '$.name') AS nm FROM nodes WHERE labels LIKE ? ORDER BY json_extract(properties, '$.name')"
+  );
+  assert.deepStrictEqual(result.params, ['%"Person"%']);
+});
+
+test('transpile parameterized LIMIT', () => {
+  const q = 'MATCH (n:Person) RETURN n LIMIT $lim';
+  const result = adapter.transpile(q, { lim: 2 });
+  assert.ok(result);
+  assert.strictEqual(
+    result.sql,
+    'SELECT id, labels, properties FROM nodes WHERE labels LIKE ? LIMIT 2'
+  );
+  assert.deepStrictEqual(result.params, ['%"Person"%']);
+});


### PR DESCRIPTION
## Summary
- support `ORDER BY id()` in SQL transpiler
- add new transpilation tests for ordering by id, variable, alias and param limit
- add e2e test verifying ORDER BY id uses transpilation

## Testing
- `npm test`