### PR TITLE
Expand transpilation tests

### DIFF
--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -474,6 +474,15 @@ runOnAdapters('match with WHERE not equals operator', async (engine, adapter) =>
   assert.strictEqual(out.length, 2);
 });
 
+runOnAdapters('match with parameterized not equals', async (engine, adapter) => {
+  const q = 'MATCH (n:Person) WHERE n.name <> $name RETURN n';
+  const result = engine.run(q, { name: 'Alice' });
+  assert.strictEqual(result.meta.transpiled, !!adapter.supportsTranspilation);
+  const out = [];
+  for await (const row of result) out.push(row.n);
+  assert.strictEqual(out.length, 2);
+});
+
 runOnAdapters('match with WHERE IN list', async (engine, adapter) => {
   const q = 'MATCH (n:Person) WHERE n.name IN ["Alice", "Bob"] RETURN n';
   const result = engine.run(q);

--- a/tests/transpile.test.js
+++ b/tests/transpile.test.js
@@ -248,6 +248,50 @@ test('transpile with WHERE not equals', () => {
   assert.deepStrictEqual(result.params, ['%"Person"%', 'Alice']);
 });
 
+test('transpile with parameterized WHERE not equals', () => {
+  const q = 'MATCH (n:Person) WHERE n.name <> $name RETURN n';
+  const result = adapter.transpile(q, { name: 'Alice' });
+  assert.ok(result);
+  assert.strictEqual(
+    result.sql,
+    "SELECT id, labels, properties FROM nodes WHERE labels LIKE ? AND json_extract(properties, '$.name') <> ?"
+  );
+  assert.deepStrictEqual(result.params, ['%"Person"%', 'Alice']);
+});
+
+test('transpile WHERE id greater than', () => {
+  const q = 'MATCH (n) WHERE id(n) > 1 RETURN n';
+  const result = adapter.transpile(q);
+  assert.ok(result);
+  assert.strictEqual(
+    result.sql,
+    'SELECT id, labels, properties FROM nodes WHERE id > ?'
+  );
+  assert.deepStrictEqual(result.params, [1]);
+});
+
+test('transpile WHERE id greater or equal parameter', () => {
+  const q = 'MATCH (n:Person) WHERE id(n) >= $id RETURN n';
+  const result = adapter.transpile(q, { id: 2 });
+  assert.ok(result);
+  assert.strictEqual(
+    result.sql,
+    'SELECT id, labels, properties FROM nodes WHERE labels LIKE ? AND id >= ?'
+  );
+  assert.deepStrictEqual(result.params, ['%"Person"%', 2]);
+});
+
+test('transpile WHERE boolean property', () => {
+  const q = 'MATCH (n:Flagged) WHERE n.active = true RETURN n';
+  const result = adapter.transpile(q);
+  assert.ok(result);
+  assert.strictEqual(
+    result.sql,
+    "SELECT id, labels, properties FROM nodes WHERE labels LIKE ? AND json_extract(properties, '$.active') = ?"
+  );
+  assert.deepStrictEqual(result.params, ['%"Flagged"%', true]);
+});
+
 test('transpile IN empty list yields constant false', () => {
   const q = 'MATCH (n:Person) WHERE n.name IN [] RETURN n';
   const result = adapter.transpile(q);


### PR DESCRIPTION
## Summary
- add unit tests for id comparisons, boolean equality, and parameterized not equals
- enable e2e transpilation check for parameterized not equals

## Testing
- `npm test`