### PR TITLE
Improve transpiler tests and features

### DIFF
--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -1308,6 +1308,7 @@ runOnAdapters('unary minus on expression', async (engine, adapter) => {
 });
 runOnAdapters('RETURN star returns all variables', async (engine, adapter) => {
   const result = engine.run('MATCH (n:Person {name:"Alice"}) RETURN *');
+  assert.strictEqual(result.meta.transpiled, !!adapter.supportsTranspilation);
   const out = [];
   for await (const row of result) out.push(row);
   assert.strictEqual(out.length, 1);
@@ -1328,6 +1329,7 @@ runOnAdapters('RETURN star with relationship chain', async (engine, adapter) => 
 });
 runOnAdapters('id() function returns node id', async (engine, adapter) => {
   const result = engine.run('MATCH (n:Person {name:"Alice"}) RETURN id(n) AS id');
+  assert.strictEqual(result.meta.transpiled, !!adapter.supportsTranspilation);
   const out = [];
   for await (const row of result) out.push(row.id);
   assert.deepStrictEqual(out, [1]);
@@ -1352,6 +1354,7 @@ runOnAdapters('type() on relationship returns rel type', async (engine, adapter)
 runOnAdapters('labels() function returns node labels', async (engine, adapter) => {
   const q = 'MATCH (n:Person {name:"Carol"}) RETURN labels(n) AS labs';
   const result = engine.run(q);
+  assert.strictEqual(result.meta.transpiled, !!adapter.supportsTranspilation);
   const out = [];
   for await (const row of result) out.push(row.labs);
   assert.deepStrictEqual(out, [['Person', 'Actor']]);

--- a/tests/transpile.test.js
+++ b/tests/transpile.test.js
@@ -604,3 +604,36 @@ test('transpile SUM aggregation', () => {
   );
   assert.deepStrictEqual(result.params, ['%"Movie"%']);
 });
+
+test('transpile RETURN id function', () => {
+  const q = 'MATCH (n:Person {name:"Alice"}) RETURN id(n) AS id';
+  const result = adapter.transpile(q);
+  assert.ok(result);
+  assert.strictEqual(
+    result.sql,
+    'SELECT id AS id FROM nodes WHERE labels LIKE ? AND json_extract(properties, \'$.name\') = ?'
+  );
+  assert.deepStrictEqual(result.params, ['%"Person"%', 'Alice']);
+});
+
+test('transpile RETURN labels function', () => {
+  const q = 'MATCH (n:Person {name:"Alice"}) RETURN labels(n) AS labs';
+  const result = adapter.transpile(q);
+  assert.ok(result);
+  assert.strictEqual(
+    result.sql,
+    'SELECT labels AS labs FROM nodes WHERE labels LIKE ? AND json_extract(properties, \'$.name\') = ?'
+  );
+  assert.deepStrictEqual(result.params, ['%"Person"%', 'Alice']);
+});
+
+test('transpile RETURN star single variable', () => {
+  const q = 'MATCH (n:Person {name:"Alice"}) RETURN *';
+  const result = adapter.transpile(q);
+  assert.ok(result);
+  assert.strictEqual(
+    result.sql,
+    'SELECT id, labels, properties FROM nodes WHERE labels LIKE ? AND json_extract(properties, \'$.name\') = ?'
+  );
+  assert.deepStrictEqual(result.params, ['%"Person"%', 'Alice']);
+});


### PR DESCRIPTION
## Summary
- expand transpilation unit tests for id(), labels() and RETURN *
- support those expressions in the sqljs adapter transpiler
- re‑enable transpilation check for several e2e tests

## Testing
- `npm test`