### PR TITLE
Expand transpiler tests

### DIFF
--- a/packages/adapters/sqljs-adapter/src/index.ts
+++ b/packages/adapters/sqljs-adapter/src/index.ts
@@ -788,6 +788,11 @@ export class SqlJsAdapter implements StorageAdapter {
             exprSql = `json_extract(properties, '$.${prop}')`;
           }
         } else if (
+          ob.expression.type === 'Id' &&
+          ob.expression.variable === matchAst.variable
+        ) {
+          exprSql = 'id';
+        } else if (
           ob.expression.type === 'Property' &&
           ob.expression.variable === matchAst.variable
         ) {

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -191,6 +191,15 @@ runOnAdapters('match node by id', async (engine, adapter) => {
   assert.strictEqual(out[0].properties.name, 'Alice');
 });
 
+runOnAdapters('match nodes by id comparison', async (engine, adapter) => {
+  const q = 'MATCH (n:Person) WHERE id(n) <= 2 RETURN n.name AS name ORDER BY id(n)';
+  const result = engine.run(q);
+  assert.strictEqual(result.meta.transpiled, !!adapter.supportsTranspilation);
+  const out = [];
+  for await (const row of result) out.push(row.name);
+  assert.deepStrictEqual(out, ['Alice', 'Bob']);
+});
+
 runOnAdapters('create node with multiple labels', async engine => {
   let node;
   for await (const row of engine.run('CREATE (n:Multi:One {v:1}) RETURN n')) node = row.n;
@@ -894,6 +903,15 @@ runOnAdapters('ORDER BY multiple expressions', async (engine, adapter) => {
   assert.deepStrictEqual(out, ['2014-Extra', '2014-John Wick', '1999-The Matrix']);
 });
 
+runOnAdapters('ORDER BY id() DESC', async (engine, adapter) => {
+  const q = 'MATCH (n:Person) RETURN n.name AS name ORDER BY id(n) DESC';
+  const result = engine.run(q);
+  assert.strictEqual(result.meta.transpiled, !!adapter.supportsTranspilation);
+  const names = [];
+  for await (const row of result) names.push(row.name);
+  assert.deepStrictEqual(names, ['Carol', 'Bob', 'Alice']);
+});
+
 runOnAdapters('RETURN multiple expressions with aliases', async (engine, adapter) => {
   const q = 'MATCH (m:Movie) RETURN m.title AS title, m.released AS year ORDER BY year';
   const result = engine.run(q);
@@ -1081,6 +1099,15 @@ runOnAdapters('MAX aggregation', async (engine, adapter) => {
   const out = [];
   for await (const row of result) out.push(row.year);
   assert.deepStrictEqual(out, [2014]);
+});
+
+runOnAdapters('AVG aggregation', async (engine, adapter) => {
+  const q = 'MATCH (m:Movie) RETURN AVG(m.released) AS avg';
+  const result = engine.run(q);
+  assert.strictEqual(result.meta.transpiled, !!adapter.supportsTranspilation);
+  const out = [];
+  for await (const row of result) out.push(row.avg);
+  assert.deepStrictEqual(out, [(1999 + 2014) / 2]);
 });
 
 runOnAdapters('MIN on empty result returns null', async (engine, adapter) => {

--- a/tests/transpile.test.js
+++ b/tests/transpile.test.js
@@ -604,3 +604,47 @@ test('transpile SUM aggregation', () => {
   );
   assert.deepStrictEqual(result.params, ['%"Movie"%']);
 });
+
+test('transpile AVG aggregation', () => {
+  const q = 'MATCH (m:Movie) RETURN AVG(m.released) AS avg';
+  const result = adapter.transpile(q);
+  assert.ok(result);
+  assert.strictEqual(
+    result.sql,
+    "SELECT AVG(json_extract(properties, '$.released')) AS avg FROM nodes WHERE labels LIKE ?"
+  );
+  assert.deepStrictEqual(result.params, ['%"Movie"%']);
+});
+
+test('transpile ORDER BY variable', () => {
+  const q = 'MATCH (n:Person) RETURN n ORDER BY n';
+  const result = adapter.transpile(q);
+  assert.ok(result);
+  assert.strictEqual(
+    result.sql,
+    'SELECT id, labels, properties FROM nodes WHERE labels LIKE ? ORDER BY id'
+  );
+  assert.deepStrictEqual(result.params, ['%"Person"%']);
+});
+
+test('transpile ORDER BY id function', () => {
+  const q = 'MATCH (n:Person) RETURN n ORDER BY id(n) DESC';
+  const result = adapter.transpile(q);
+  assert.ok(result);
+  assert.strictEqual(
+    result.sql,
+    'SELECT id, labels, properties FROM nodes WHERE labels LIKE ? ORDER BY id DESC'
+  );
+  assert.deepStrictEqual(result.params, ['%"Person"%']);
+});
+
+test('transpile WHERE id <= comparison', () => {
+  const q = 'MATCH (n) WHERE id(n) <= 2 RETURN n';
+  const result = adapter.transpile(q);
+  assert.ok(result);
+  assert.strictEqual(
+    result.sql,
+    'SELECT id, labels, properties FROM nodes WHERE id <= ?'
+  );
+  assert.deepStrictEqual(result.params, [2]);
+});


### PR DESCRIPTION
## Summary
- improve SQL transpiler to allow `ORDER BY id()`
- extend unit tests for transpilation
- add e2e cases checking id comparisons, order by id and AVG aggregation

## Testing
- `npm test`