### PR TITLE
Improve transpiler tests and COUNT DISTINCT support

### DIFF
--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -1001,6 +1001,7 @@ runOnAdapters('COUNT DISTINCT aggregation', async (engine, adapter) => {
   for await (const _ of engine.run('CREATE (n:Person {name:"Bob"})')) {}
   const q = 'MATCH (p:Person) RETURN COUNT(DISTINCT p.name) AS cnt';
   const result = engine.run(q);
+  assert.strictEqual(result.meta.transpiled, !!adapter.supportsTranspilation);
   const out = [];
   for await (const row of result) out.push(row.cnt);
   assert.strictEqual(out[0], 3);
@@ -1009,6 +1010,7 @@ runOnAdapters('COUNT DISTINCT aggregation', async (engine, adapter) => {
 runOnAdapters('COUNT DISTINCT star counts rows', async (engine, adapter) => {
   const q = 'MATCH (p:Person) RETURN COUNT(DISTINCT *) AS cnt';
   const result = engine.run(q);
+  assert.strictEqual(result.meta.transpiled, !!adapter.supportsTranspilation);
   const out = [];
   for await (const row of result) out.push(row.cnt);
   assert.strictEqual(out[0], 3);


### PR DESCRIPTION
## Summary
- extend transpile tests with parameterized LIMIT, ORDER BY id and COUNT DISTINCT
- implement COUNT DISTINCT and ORDER BY id in the SQL.js adapter
- enable transpilation check for COUNT DISTINCT e2e tests

## Testing
- `npm test`