### PR TITLE
Add optional MATCH transpilation

### DIFF
--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -831,6 +831,7 @@ runOnAdapters('relationships() on path returns relationships', async engine => {
 
 runOnAdapters('OPTIONAL MATCH missing returns null row', async (engine, adapter) => {
   const result = engine.run('OPTIONAL MATCH (n:Missing) RETURN n');
+  assert.strictEqual(result.meta.transpiled, !!adapter.supportsTranspilation);
   const out = [];
   for await (const row of result) out.push(row.n);
   assert.strictEqual(out.length, 1);
@@ -840,6 +841,7 @@ runOnAdapters('OPTIONAL MATCH missing returns null row', async (engine, adapter)
 runOnAdapters('OPTIONAL MATCH existing node returns it', async (engine, adapter) => {
   const q = 'OPTIONAL MATCH (n:Person {name:"Alice"}) RETURN n';
   const result = engine.run(q);
+  assert.strictEqual(result.meta.transpiled, !!adapter.supportsTranspilation);
   const out = [];
   for await (const row of result) out.push(row.n);
   assert.strictEqual(out.length, 1);

--- a/tests/transpile.test.js
+++ b/tests/transpile.test.js
@@ -49,6 +49,27 @@ test('transpile match by property only', () => {
   assert.deepStrictEqual(result.params, ['Alice']);
 });
 
+test('transpile optional match simple return', () => {
+  const result = adapter.transpile('OPTIONAL MATCH (n:Person {name:"Alice"}) RETURN n');
+  assert.ok(result);
+  assert.strictEqual(
+    result.sql,
+    'SELECT id, labels, properties FROM nodes WHERE labels LIKE ? AND json_extract(properties, \'$.name\') = ?'
+  );
+  assert.deepStrictEqual(result.params, ['%"Person"%', 'Alice']);
+});
+
+test('transpile optional match property return', () => {
+  const q = 'OPTIONAL MATCH (n:Person {name:"Alice"}) RETURN n.name AS name';
+  const result = adapter.transpile(q);
+  assert.ok(result);
+  assert.strictEqual(
+    result.sql,
+    'SELECT json_extract(properties, \'$.name\') AS name FROM nodes WHERE labels LIKE ? AND json_extract(properties, \'$.name\') = ?'
+  );
+  assert.deepStrictEqual(result.params, ['%"Person"%', 'Alice']);
+});
+
 test('transpile match with alias', () => {
   const result = adapter.transpile('MATCH (n:Person) RETURN n AS person');
   assert.ok(result);


### PR DESCRIPTION
## Summary
- support transpiling OPTIONAL MATCH queries in the sql.js adapter
- add unit tests for OPTIONAL MATCH transpilation
- re-enable transpilation checks for OPTIONAL MATCH e2e tests

## Testing
- `npm test`