### PR TITLE
Add auto publish workflow on master

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,23 +1,29 @@
 name: Publish to npm
 
 on:
-  release:
-    types: [published]
+  push:
+    branches: [master]
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
           node-version: 18
           registry-url: 'https://registry.npmjs.org/'
       - run: npm install
+      - run: ./bump-version.sh
+      - run: git config user.name 'github-actions'
+      - run: git config user.email 'github-actions@github.com'
+      - run: git push
       - run: npm run build
       - run: npm publish --workspaces --access public
         env:

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+CORE_VERSION=$(npm version patch --workspace packages/core --no-workspaces-update --no-git-tag-version | tail -n1)
+CORE_VERSION=${CORE_VERSION#v}
+for pkg in packages/adapters/json-adapter packages/adapters/sqljs-adapter packages/adapters/sqljs-schema-adapter; do
+  npm pkg set "dependencies.@cypher-anywhere/core"="$CORE_VERSION" -w "$pkg"
+  npm version patch --workspace "$pkg" --no-workspaces-update --no-git-tag-version
+done
+git add packages/*/package.json
+git commit -m "chore: bump versions to $CORE_VERSION" || echo "No version changes"


### PR DESCRIPTION
## Summary
- publish npm package on every push to `master`
- add helper script to bump package versions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68483d2ff8a48326beeec4daf1416cf1