### PR TITLE
Fix version bump commit paths

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,9 +20,9 @@ jobs:
           node-version: 18
           registry-url: 'https://registry.npmjs.org/'
       - run: npm install
-      - run: ./bump-version.sh
       - run: git config user.name 'github-actions'
       - run: git config user.email 'github-actions@github.com'
+      - run: ./bump-version.sh
       - run: git push
       - run: npm run build
       - run: npm publish --workspaces --access public

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -6,5 +6,5 @@ for pkg in packages/adapters/json-adapter packages/adapters/sqljs-adapter packag
   npm pkg set "dependencies.@cypher-anywhere/core"="$CORE_VERSION" -w "$pkg"
   npm version patch --workspace "$pkg" --no-workspaces-update --no-git-tag-version
 done
-git add packages/*/package.json
+git add packages/core/package.json packages/adapters/*/package.json
 git commit -m "chore: bump versions to $CORE_VERSION" || echo "No version changes"


### PR DESCRIPTION
## Summary
- fix the `bump-version.sh` script so it stages adapter package.json files
- configure git before running the bump script in the publish workflow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848492beccc8326b71ad8e2a8701ff4