### PR TITLE
Automate version bump and npm release

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,26 @@
+name: Bump Version
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  bump:
+    if: github.actor != 'github-actions'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm install
+      - run: git config user.name 'github-actions'
+      - run: git config user.email 'github-actions@github.com'
+      - run: ./bump-version.sh
+      - run: git push origin HEAD:master --follow-tags

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,11 +2,11 @@ name: Publish to npm
 
 on:
   push:
-    branches: [master]
+    tags: ["v*"]
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   publish:
@@ -20,10 +20,6 @@ jobs:
           node-version: 18
           registry-url: 'https://registry.npmjs.org/'
       - run: npm install
-      - run: git config user.name 'github-actions'
-      - run: git config user.email 'github-actions@github.com'
-      - run: ./bump-version.sh
-      - run: git push
       - run: npm run build
       - run: npm publish --workspaces --access public
         env:

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -7,4 +7,4 @@ for pkg in packages/adapters/json-adapter packages/adapters/sqljs-adapter packag
   npm version patch --workspace "$pkg" --no-workspaces-update --no-git-tag-version
 done
 git add packages/core/package.json packages/adapters/*/package.json
-git commit -m "chore: bump versions to $CORE_VERSION" || echo "No version changes"
+git commit -m "chore: bump versions to $CORE_VERSION" && git tag "v$CORE_VERSION" || echo "No version changes"


### PR DESCRIPTION
## Summary
- bump script now tags the new version
- add workflow to automatically bump and push tagged versions
- publish workflow now triggers on version tags

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68484afe0c2083268c6d382bc5edd2e4