### PR TITLE
Fix version bump tags for publish action

### DIFF
--- a/bump-version.sh
+++ b/bump-version.sh
@@ -7,4 +7,4 @@ for pkg in packages/adapters/json-adapter packages/adapters/sqljs-adapter packag
   npm version patch --workspace "$pkg" --no-workspaces-update --no-git-tag-version
 done
 git add packages/core/package.json packages/adapters/*/package.json
-git commit -m "chore: bump versions to $CORE_VERSION" && git tag "v$CORE_VERSION" || echo "No version changes"
+git commit -m "chore: bump versions to $CORE_VERSION" && git tag -a "v$CORE_VERSION" -m "Release $CORE_VERSION" || echo "No version changes"


### PR DESCRIPTION
## Summary
- ensure version bump script creates annotated tags

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68484cd8c33883269c116355d4ec8110