### PR TITLE
Use PAT for bump workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ secrets.PAT_TOKEN }}
       - uses: actions/setup-node@v3
         with:
           node-version: 18

--- a/README.md
+++ b/README.md
@@ -64,3 +64,14 @@ npm test    # executes the Jest suite
 ```
 
 For more details, see the [design document](./design_document.md).
+
+## Release & Publishing
+
+Version bumps are automated via the `Bump Version` workflow. To allow the
+resulting tag push to trigger the `Publish to npm` workflow you must provide a
+personal access token (PAT):
+
+1. Create a PAT with the `repo` scope and add it as a repository secret named
+   `PAT_TOKEN`.
+2. The `bump-version.yml` workflow uses this secret when pushing the bump commit
+   and tag so GitHub treats it as a normal user push and triggers publishing.


### PR DESCRIPTION
## Summary
- push bump commit using a repository PAT
- document PAT-based release procedure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848531dd5d083269b2233c49ee9fe25