### PR TITLE
Trigger publish workflow without PAT

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -16,7 +16,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          token: ${{ secrets.PAT_TOKEN }}
       - uses: actions/setup-node@v3
         with:
           node-version: 18
@@ -25,3 +24,11 @@ jobs:
       - run: git config user.email 'github-actions@github.com'
       - run: ./bump-version.sh
       - run: git push origin HEAD:master --follow-tags
+      - name: Trigger publish workflow
+        run: |
+          TAG=$(git describe --tags --abbrev=0)
+          gh api \
+            repos/${{ github.repository }}/actions/workflows/publish.yml/dispatches \
+            -f ref=$TAG
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -67,11 +67,7 @@ For more details, see the [design document](./design_document.md).
 
 ## Release & Publishing
 
-Version bumps are automated via the `Bump Version` workflow. To allow the
-resulting tag push to trigger the `Publish to npm` workflow you must provide a
-personal access token (PAT):
-
-1. Create a PAT with the `repo` scope and add it as a repository secret named
-   `PAT_TOKEN`.
-2. The `bump-version.yml` workflow uses this secret when pushing the bump commit
-   and tag so GitHub treats it as a normal user push and triggers publishing.
+Version bumps are automated via the `Bump Version` workflow. The workflow
+pushes the updated commit and tag using the built-in `GITHUB_TOKEN` and then
+manually triggers the `Publish to npm` workflow via `workflow_dispatch`. No
+personal access token is required.


### PR DESCRIPTION
## Summary
- use default `GITHUB_TOKEN` when bumping versions
- trigger the `Publish to npm` workflow via `workflow_dispatch`
- update README about release automation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68486274cd088326b6a60a5aa89e20d5