### PR TITLE
Fix publish workflow dispatch

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   bump:


### PR DESCRIPTION
## Summary
- allow Actions token to trigger publish workflow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684865df30f08326876631628495e211